### PR TITLE
daemonize websocket thread (kill when main exits)

### DIFF
--- a/GDAX/WebsocketClient.py
+++ b/GDAX/WebsocketClient.py
@@ -21,6 +21,7 @@ class WebsocketClient(object):
             self.listen()
 
         self.thread = Thread(target=go)
+        self.thread.daemon = True
         self.thread.start()
 
     def connect(self):


### PR DESCRIPTION
from https://docs.python.org/2/library/threading.html:

```
A thread can be flagged as a “daemon thread”. The significance of
this flag is that the entire Python program exits when only daemon
threads are left. The initial value is inherited from the creating
thread. The flag can be set through the daemon property.
```