### PR TITLE
Added cancel all orders ability

### DIFF
--- a/GDAX/AuthenticatedClient.py
+++ b/GDAX/AuthenticatedClient.py
@@ -71,6 +71,13 @@ class AuthenticatedClient(PublicClient):
         r = requests.delete(self.url + '/orders/' + orderId, auth=self.auth)
         return r.json()
 
+    def cancelOrders(self, product_id=""):
+        payload = {
+            "product_id": product_id
+        }
+        r = requests.delete(self.url + '/orders', data=json.dumps(payload), auth=self.auth)
+        return r.json()
+
     def getOrder(self, orderId):
         r = requests.get(self.url + '/orders/' + orderId, auth=self.auth)
         return r.json()


### PR DESCRIPTION
I noticed there wasn't the ability to cancel all orders, so I added cancelOrders to AuthenticatedClient. The code works but is probably sloppy if you want to clean it up.

By the way, "product_id" is optional when cancelling all orders. I wasn't sure how to implement this in the code but is probably an easy fix.