### PR TITLE
passing a string as WebsocktClient prodects paramater not working

### DIFF
--- a/GDAX/WebsocketClient.py
+++ b/GDAX/WebsocketClient.py
@@ -18,8 +18,10 @@ class WebsocketClient(object):
             url = "wss://ws-feed.gdax.com"
 
         if products is None:
-            products = ["BTC-USD"]
-
+            products = ["BTC-USD"]        
+        elif not isinstance(products, list):
+            products = [products]
+            
         self.url = url
         if self.url[-1] == "/":
             self.url = self.url[:-1]


### PR DESCRIPTION
previously unless you entered a list into the products parameter the connection was not returning responses. passing a string is valid according to the example in the README