### PR TITLE
Fixed type error with print formatter

### DIFF
--- a/GDAX/WebsocketClient.py
+++ b/GDAX/WebsocketClient.py
@@ -101,6 +101,6 @@ if __name__ == "__main__":
     print(wsClient.url, wsClient.products)
     # Do some logic with the data
     while (wsClient.MessageCount < 500):
-        print ("\nMessageCount =", "%i \n") % wsClient.MessageCount
+        print("\nMessageCount =", "%i \n" % wsClient.MessageCount)
         time.sleep(1)
     wsClient.close()


### PR DESCRIPTION
Fixed the bug raised in #35 with exactly what @pretzel729 had described.

Additionally; @danpaquin can we change the project to use the newer string formatting method `"{}".format('string'` instead of the older obsolete % substitutions?