### PR TITLE
Accept kwargs in buy and sell

### DIFF
--- a/GDAX/AuthenticatedClient.py
+++ b/GDAX/AuthenticatedClient.py
@@ -56,16 +56,20 @@ class AuthenticatedClient(PublicClient):
             self.holdsPagination(accountId, list, r.headers["cb-after"])
         return list
 
-    def buy(self, buyParams):
-        buyParams["side"] = "buy"
-        if not buyParams["product_id"]:
-            buyParams["product_id"] = self.productId
-        r = requests.post(self.url + '/orders', data=json.dumps(buyParams), auth=self.auth)
+    def buy(self, **kwargs):
+        kwargs["side"] = "buy"
+        if not "product_id" in kwargs:
+            kwargs["product_id"] = self.productId
+        r = requests.post(self.url + '/orders',
+                          data=json.dumps(kwargs),
+                          auth=self.auth)
         return r.json()
 
-    def sell(self, sellParams):
-        sellParams["side"] = "sell"
-        r = requests.post(self.url + '/orders', data=json.dumps(sellParams), auth=self.auth)
+    def sell(self, **kwargs):
+        kwargs["side"] = "sell"
+        r = requests.post(self.url + '/orders',
+                          data=json.dumps(kwargs),
+                          auth=self.auth)
         return r.json()
 
     def cancelOrder(self, orderId):


### PR DESCRIPTION
Previously buy and sell accepted a single dict of arbitrary parameters.
That worked, but it wasn't very pythonic.

This commit changes them both to accept arbitrary kwargs. The
functionality is the same, but now it looks like python.

I have also taken the opportunity to format the lines I altered in
accordance with [PEP-8](https://www.python.org/dev/peps/pep-0008/).

Cf. #8 