### PR TITLE
Add is_empty method to OrderBook

### DIFF
--- a/GDAX/OrderBook.py
+++ b/GDAX/OrderBook.py
@@ -221,6 +221,9 @@ class OrderBook(WebsocketClient):
 
     def set_bids(self, price, bids):
         self._bids.insert(price, bids)
+        
+    def is_empty(self):
+        return len(self._asks) == 0 or len(self._bids) == 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Before the order book is loaded, `get_ask`, `get_bid`, etc. will throw an error. The `is_empty` method would provide a convenient way to check first.