### PR TITLE
change GDAX to gdax in setup.py and correct spelling in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,9 @@ auth_client.get_order("d50ec984-77a8-460a-b958-66f114b0de9b")
 ```python
 auth_client.get_fills()
 # Get fills for a specific order
-auth_client.get_fills(orderId="d50ec984-77a8-460a-b958-66f114b0de9b")
+auth_client.get_fills(order_id="d50ec984-77a8-460a-b958-66f114b0de9b")
 # Get fills for a specific product
-auth_client.get_fills(productId="ETH-BTC")
+auth_client.get_fills(product_id="ETH-BTC")
 ```
 
 - [deposit & withdraw](https://docs.gdax.com/#depositwithdraw)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 ]
 
 setup(
-    name='GDAX',
+    name='gdax',
     version='0.3.1',
     author='Daniel Paquin',
     author_email='dpaq34@gmail.com',


### PR DESCRIPTION
due to recent pep8 refactoring, several places have been updated correctly. 

The name in `setup.py` need to be changed from GDAX to gdax, otherwise, import gdax won't work (if you install from source)