### PR TITLE
Clean up PublicClient. Add doctrings + tests.

### DIFF
--- a/gdax/public_client.py
+++ b/gdax/public_client.py
@@ -8,69 +8,244 @@ import requests
 
 
 class PublicClient(object):
-    def __init__(self, api_url="https://api.gdax.com", product_id="BTC-USD"):
-        self.url = api_url.rstrip("/")
-        self.product_id = product_id
+    """GDAX public client API.
+
+    All requests default to the `product_id` specified at object
+    creation if not otherwise specified.
+
+    Attributes:
+        url (Optional[str]): API URL. Defaults to GDAX API.
+
+    """
+
+    def __init__(self, api_url='https://api.gdax.com'):
+        """Create GDAX API public client.
+
+        Args:
+            api_url (Optional[str]): API URL. Defaults to GDAX API.
+
+        """
+        self.url = api_url.rstrip('/')
 
     def get_products(self):
+        """Get a list of available currency pairs for trading.
+
+        Returns:
+            list: Info about all currency pairs. Example::
+                [
+                    {
+                        "id": "BTC-USD",
+                        "display_name": "BTC/USD",
+                        "base_currency": "BTC",
+                        "quote_currency": "USD",
+                        "base_min_size": "0.01",
+                        "base_max_size": "10000.00",
+                        "quote_increment": "0.01"
+                    }
+                ]
+
+        """
         r = requests.get(self.url + '/products')
         # r.raise_for_status()
         return r.json()
 
-    def get_product_order_book(self, json=None, level=2, product=''):
-        if type(json) is dict:
-            if "product" in json:
-                product = json["product"]
-            if "level" in json:
-                level = json['level']
-        r = requests.get(self.url + '/products/{}/book?level={}'.format(product or self.product_id, str(level)))
+    def get_product_order_book(self, product_id, level=1):
+        """Get a list of open orders for a product.
+
+        The amount of detail shown can be customized with the `level`
+        parameter:
+        * 1: Only the best bid and ask
+        * 2: Top 50 bids and asks (aggregated)
+        * 3: Full order book (non aggregated)
+
+        Level 1 and Level 2 are recommended for polling. For the most
+        up-to-date data, consider using the websocket stream.
+
+        **Caution**: Level 3 is only recommended for users wishing to
+        maintain a full real-time order book using the websocket
+        stream. Abuse of Level 3 via polling will cause your access to
+        be limited or blocked.
+
+        Args:
+            product_id (str): Product
+            level (Optional[int]): Order book level (1, 2, or 3).
+                Default is 1.
+
+        Returns:
+            dict: Order book. Example for level 1::
+                {
+                    "sequence": "3",
+                    "bids": [
+                        [ price, size, num-orders ],
+                    ],
+                    "asks": [
+                        [ price, size, num-orders ],
+                    ]
+                }
+
+        """
+        params = {'level': level}
+        r = requests.get(self.url + '/products/{}/book'
+                         .format(product_id), params=params)
         # r.raise_for_status()
         return r.json()
 
-    def get_product_ticker(self, json=None, product=''):
-        if type(json) is dict:
-            if "product" in json:
-                product = json["product"]
-        r = requests.get(self.url + '/products/{}/ticker'.format(product or self.product_id))
+    def get_product_ticker(self, product_id):
+        """Snapshot about the last trade (tick), best bid/ask and 24h volume.
+
+        **Caution**: Polling is discouraged in favor of connecting via
+        the websocket stream and listening for match messages.
+
+        Args:
+            product_id (str): Product
+
+        Returns:
+            dict: Ticker info. Example::
+                {
+                  "trade_id": 4729088,
+                  "price": "333.99",
+                  "size": "0.193",
+                  "bid": "333.98",
+                  "ask": "333.99",
+                  "volume": "5957.11914015",
+                  "time": "2015-11-14T20:46:03.511254Z"
+                }
+
+        """
+        r = requests.get(self.url + '/products/{}/ticker'
+                         .format(product_id))
         # r.raise_for_status()
         return r.json()
 
-    def get_product_trades(self, json=None, product=''):
-        if type(json) is dict:
-            if "product" in json:
-                product = json["product"]
-        r = requests.get(self.url + '/products/{}/trades'.format(product or self.product_id))
+    def get_product_trades(self, product_id):
+        """List the latest trades for a product.
+
+        Args:
+            product_id (str): Product
+
+        Returns:
+            list: Latest trades. Example::
+                [{
+                    "time": "2014-11-07T22:19:28.578544Z",
+                    "trade_id": 74,
+                    "price": "10.00000000",
+                    "size": "0.01000000",
+                    "side": "buy"
+                }, {
+                    "time": "2014-11-07T01:08:43.642366Z",
+                    "trade_id": 73,
+                    "price": "100.00000000",
+                    "size": "0.01000000",
+                    "side": "sell"
+                }]
+
+        """
+        r = requests.get(self.url + '/products/{}/trades'.format(product_id))
         # r.raise_for_status()
         return r.json()
 
-    def get_product_historic_rates(self, json=None, product='', start='', end='', granularity=''):
-        payload = {}
-        if type(json) is dict:
-            if "product" in json:
-                product = json["product"]
-            payload = json
-        else:
-            payload["start"] = start
-            payload["end"] = end
-            payload["granularity"] = granularity
-        r = requests.get(self.url + '/products/{}/candles'.format(product or self.product_id), params=payload)
+    def get_product_historic_rates(self, product_id, start=None, end=None,
+                                   granularity=None):
+        """Historic rates for a product.
+
+        Rates are returned in grouped buckets based on requested
+        `granularity`. If start, end, and granularity aren't provided,
+        the exchange will assume some (currently unknown) default values.
+
+        Historical rate data may be incomplete. No data is published for
+        intervals where there are no ticks.
+
+        **Caution**: Historical rates should not be polled frequently.
+        If you need real-time information, use the trade and book
+        endpoints along with the websocket feed.
+
+        The maximum number of data points for a single request is 200
+        candles. If your selection of start/end time and granularity
+        will result in more than 200 data points, your request will be
+        rejected. If you wish to retrieve fine granularity data over a
+        larger time range, you will need to make multiple requests with
+        new start/end ranges.
+
+        Args:
+            product_id (str): Product
+            start (Optional[str]): Start time in ISO 8601
+            end (Optional[str]): End time in ISO 8601
+            granularity (Optional[str]): Desired time slice in seconds
+
+        Returns:
+            list: Historic candle data. Example::
+                [
+                    [ time, low, high, open, close, volume ],
+                    [ 1415398768, 0.32, 4.2, 0.35, 4.2, 12.3 ],
+                    ...
+                ]
+
+        """
+        params = {}
+        if start is not None:
+            params['start'] = start
+        if end is not None:
+            params['end'] = end
+        if granularity is not None:
+            params['granularity'] = granularity
+        r = requests.get(self.url + '/products/{}/candles'
+                         .format(product_id), params=params)
         # r.raise_for_status()
         return r.json()
 
-    def get_product_24hr_stats(self, json=None, product=''):
-        if type(json) is dict:
-            if "product" in json:
-                product = json["product"]
-        r = requests.get(self.url + '/products/{}/stats'.format(product or self.product_id))
+    def get_product_24hr_stats(self, product_id):
+        """Get 24 hr stats for the product.
+
+        Args:
+            product_id (str): Product
+
+        Returns:
+            dict: 24 hour stats. Volume is in base currency units.
+                Open, high, low are in quote currency units. Example::
+                    {
+                        "open": "34.19000000",
+                        "high": "95.70000000",
+                        "low": "7.06000000",
+                        "volume": "2.41000000"
+                    }
+
+        """
+        r = requests.get(self.url + '/products/{}/stats'.format(product_id))
         # r.raise_for_status()
         return r.json()
 
     def get_currencies(self):
+        """List known currencies.
+
+        Returns:
+            list: List of currencies. Example::
+                [{
+                    "id": "BTC",
+                    "name": "Bitcoin",
+                    "min_size": "0.00000001"
+                }, {
+                    "id": "USD",
+                    "name": "United States Dollar",
+                    "min_size": "0.01000000"
+                }]
+
+        """
         r = requests.get(self.url + '/currencies')
         # r.raise_for_status()
         return r.json()
 
     def get_time(self):
+        """Get the API server time.
+
+        Returns:
+            dict: Server time in ISO and epoch format (decimal seconds
+                since Unix epoch). Example::
+                    {
+                        "iso": "2015-01-07T23:47:25.201Z",
+                        "epoch": 1420674445.201
+                    }
+
+        """
         r = requests.get(self.url + '/time')
         # r.raise_for_status()
         return r.json()

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ install_requires = [
     'websocket-client==0.40.0',
 ]
 
+tests_require = [
+    'pytest',
+    ]
+
 setup(
     name='gdax',
     version='0.3.1',
@@ -18,6 +22,7 @@ setup(
     url='https://github.com/danpaquin/GDAX-Python',
     packages=find_packages(),
     install_requires=install_requires,
+    tests_require=tests_require,
     description='The unofficial Python client for the GDAX API',
     download_url='https://github.com/danpaquin/GDAX-Python/archive/master.zip',
     keywords=['gdax', 'gdax-api', 'orderbook', 'trade', 'bitcoin', 'ethereum', 'BTC', 'ETH', 'client', 'api', 'wrapper', 'exchange', 'crypto', 'currency', 'trading', 'trading-api', 'coinbase'],

--- a/tests/test_public_client.py
+++ b/tests/test_public_client.py
@@ -1,0 +1,52 @@
+import pytest
+import gdax
+
+
+@pytest.fixture(scope='module')
+def client():
+    return gdax.PublicClient()
+
+
+@pytest.mark.usefixtures('client')
+class TestPublicClient(object):
+    def test_get_products(self, client):
+        r = client.get_products()
+        assert type(r) is list
+
+    def test_get_product_order_book(self, client):
+        r = client.get_product_order_book('BTC-USD')
+        assert type(r) is dict
+        r = client.get_product_order_book('BTC-USD', level=2)
+        assert type(r) is dict
+        assert 'asks' in r
+        assert 'bids' in r
+
+    def test_get_product_ticker(self, client):
+        r = client.get_product_ticker('BTC-USD')
+        assert type(r) is dict
+        assert 'ask' in r
+        assert 'trade_id' in r
+
+    def test_get_product_trades(self, client):
+        r = client.get_product_trades('BTC-USD')
+        assert type(r) is list
+        assert 'trade_id' in r[0]
+
+    def test_get_historic_rates(self, client):
+        r = client.get_product_historic_rates('BTC-USD')
+        assert type(r) is list
+
+    def test_get_product_24hr_stats(self, client):
+        r = client.get_product_24hr_stats('BTC-USD')
+        assert type(r) is dict
+        assert 'volume_30day' in r
+
+    def test_get_currencies(self, client):
+        r = client.get_currencies()
+        assert type(r) is list
+        assert 'name' in r[0]
+
+    def test_get_time(self, client):
+        r = client.get_time()
+        assert type(r) is dict
+        assert 'iso' in r


### PR DESCRIPTION
* Drop the mixed keyword/dict interface in favor of keywords only.
* Add docstrings based on Google format.
* Add simple unit tests to verify that API functions pull data from GDAX.

Having two different interfaces to the same functions (positional/keywords arguments vs the dict interface aka `json` variable) is confusing to the user and creates more headache for logic to handle the two cases. Only using named variables, you can still get both worlds since a user can use `**` to unpack a dict:
```
params = {'level': 1, 'product_id': 'BTC-USD'}
client = gdax.PublicClient()
client.get_product_order_book(**params)
```
or use keywords:
```
client.get_product_order_book(product_id='BTC-USD', level=1)
```
or positional arguments:
```
client.get_product_order_book('BTC-USD', 1)
```

General guidelines for this refactor can be found in #60.


