### PR TITLE
Use explicit classes when calling super()

### DIFF
--- a/gdax/authenticated_client.py
+++ b/gdax/authenticated_client.py
@@ -16,7 +16,7 @@ from gdax.public_client import PublicClient
 
 class AuthenticatedClient(PublicClient):
     def __init__(self, key, b64secret, passphrase, api_url="https://api.gdax.com", product_id="BTC-USD"):
-        super(self.__class__, self).__init__(api_url, product_id)
+        super(AuthenticatedClient, self).__init__(api_url, product_id)
         self.auth = GdaxAuth(key, b64secret, passphrase)
 
     def get_account(self, account_id):

--- a/gdax/order_book.py
+++ b/gdax/order_book.py
@@ -14,7 +14,7 @@ from gdax.websocket_client import WebsocketClient
 
 class OrderBook(WebsocketClient):
     def __init__(self, product_id='BTC-USD'):
-        super(self.__class__, self).__init__(products=product_id)
+        super(OrderBook, self).__init__(products=product_id)
         self._asks = RBTree()
         self._bids = RBTree()
         self._client = PublicClient(product_id=product_id)


### PR DESCRIPTION
In python3, we can just say `super().__init__()`. For python2
compatibility, we need to provide two parameters to `super`:
the inheriting class, and the bound object.

In 2655428, we introduced calls to `super` specifying `self.__class__`
for the first parameter. This is a problem (at least in python3) because
that results in the inheriting class itself used for binding. Thus when
we call `__init__`, it is not the `super`'s `__init__` that is called.

This change-set fixes that problem by explicitly specifying the first
parameter of `super` calls. This works in both python3 and python2.