### PR TITLE
self.__class__ as first argument to super() causes inheritance problems

### DIFF
--- a/gdax/authenticated_client.py
+++ b/gdax/authenticated_client.py
@@ -16,7 +16,7 @@ from gdax.public_client import PublicClient
 
 class AuthenticatedClient(PublicClient):
     def __init__(self, key, b64secret, passphrase, api_url="https://api.gdax.com", product_id="BTC-USD"):
-        super(self.__class__, self).__init__(api_url, product_id)
+        super(AuthenticatedClient, self).__init__(api_url, product_id)
         self.auth = GdaxAuth(key, b64secret, passphrase)
 
     def get_account(self, account_id):

--- a/gdax/order_book.py
+++ b/gdax/order_book.py
@@ -14,7 +14,7 @@ from gdax.websocket_client import WebsocketClient
 
 class OrderBook(WebsocketClient):
     def __init__(self, product_id='BTC-USD'):
-        super(self.__class__, self).__init__(products=product_id)
+        super(OrderBook, self).__init__(products=product_id)
         self._asks = RBTree()
         self._bids = RBTree()
         self._client = PublicClient(product_id=product_id)


### PR DESCRIPTION
`super(self.__class__, self)`... is a bug. AFAIK there isn't a good way around repeating the class name. 
For example, when subclassing **OrderBook** like so:

```
import gdax

class SubOrderBook(gdax.OrderBook):
    def __init__(self):
        super(SubOrderBook, self).__init__(
            product_id = 'BTC-USD'
        )

ob = SubOrderBook()
```

The following error is encountered:

```
$ python example.py
Traceback (most recent call last):
  File "example.py", line 9, in <module>
    ob = SubOrderBook()
  File "example.py", line 6, in __init__
    product_id = 'BTC-USD'
  File "X:\Python36\lib\site-packages\gdax-0.3.1-py3.6.egg\gdax\order_book.py", line 17, in __init__
TypeError: __init__() got an unexpected keyword argument 'products'

```
This is because `self.__class__` is actually **SubOrderBook**, even inside the `__init__` method of **OrderBook**. `self.__class__` cannot be used for this purpose, you should use the actual class name. This pull request has the relevant fixes (very simple).