### PR TITLE
AuthenticatedClient overhaul, docstrings, and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ public_client.get_product_order_book('BTC-USD', level=1)
 public_client.get_product_ticker(product_id='ETH-USD')
 ```
 
-- [get_product_trades](https://docs.gdax.com/#get-trades)
+- [get_product_trades](https://docs.gdax.com/#get-trades) (paginated)
 ```python
 # Get the product trades for a specific product.
+# Returns a generator
 public_client.get_product_trades(product_id='ETH-USD')
 ```
 
@@ -169,13 +170,36 @@ auth_client.get_account_holds("7d0f7d8e-dd34-4d9c-a846-06f431c381ba")
 # Buy 0.01 BTC @ 100 USD
 auth_client.buy(price='100.00', #USD
                size='0.01', #BTC
+               order_type='limit',
                product_id='BTC-USD')
 ```
 ```python
 # Sell 0.01 BTC @ 200 USD
 auth_client.sell(price='200.00', #USD
                 size='0.01', #BTC
+                order_type='limit',
                 product_id='BTC-USD')
+```
+```python
+# Limit order-specific method
+auth_client.place_limit_order(product_id='BTC-USD', 
+                              side='buy', 
+                              price='200.00', 
+                              size='0.01')
+```
+```python
+# Place a market order by specifying amount of USD to use. 
+# Alternatively, `size` could be used to specify quantity in BTC amount.
+auth_client.place_market_order(product_id='BTC-USD', 
+                               side='buy', 
+                               funds='100.00')
+```
+```python
+# Stop order. `funds` can be used instead of `size` here.
+auth_client.place_stop_order(product_id='BTC-USD', 
+                              side='buy', 
+                              price='200.00', 
+                              size='0.01')
 ```
 
 - [cancel_order](https://docs.gdax.com/#cancel-an-order)

--- a/README.md
+++ b/README.md
@@ -2,38 +2,49 @@
 The Python client for the [GDAX API](https://docs.gdax.com/) (formerly known as the Coinbase Exchange API)
 
 ##### Provided under MIT License by Daniel Paquin.
-*Note: this library may be subtly broken or buggy. The code is released under the MIT License – please take the following message to heart:*
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*Note: this library may be subtly broken or buggy. The code is released under 
+the MIT License – please take the following message to heart:*
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ## Benefits
 - A simple to use python wrapper for both public and authenticated endpoints.
-- In about 10 minutes, you could be programmatically trading on one of the largest Bitcoin exchanges in the *world*!
-- Do not worry about handling the nuances of the API with easy-to-use methods for every API endpoint.
-- Gain an advantage in the market by getting under the hood of GDAX to learn what and who is *really* behind every tick.
+- In about 10 minutes, you could be programmatically trading on one of the 
+largest Bitcoin exchanges in the *world*!
+- Do not worry about handling the nuances of the API with easy-to-use methods 
+for every API endpoint.
+- Gain an advantage in the market by getting under the hood of GDAX to learn 
+what and who is *really* behind every tick.
 
 ## Under Development
-- Test Scripts **on dev branch**
-- Additional Functionality for *WebsocketClient*, including a real-time order book
+- Unit testing
+- Additional Functionality for *WebsocketClient*, including a real-time order 
+book
 - FIX API Client **Looking for support**
 
 ## Getting Started
-This README is documentation on the syntax of the python client presented in this repository.  **In order to use this wrapper to its full potential, you must familiarize yourself with the official GDAX documentation.**
+This README is documentation on the syntax of the python client presented in 
+this repository.  **In order to use this wrapper to its full potential, you must 
+familiarize yourself with the official GDAX documentation.**
 
 - https://docs.gdax.com/
 
 - You may manually install the project or use ```pip```:
 ```python
-pip install GDAX
+pip install gdax
 ```
 
 ### Public Client
-Only some endpoints in the API are available to everyone.  The public endpoints can be reached using ```PublicClient```
+Only some endpoints in the API are available to everyone.  The public endpoints 
+can be reached using ```PublicClient```
 
 ```python
 import gdax
 public_client = gdax.PublicClient()
-# Set a default product
-public_client = gdax.PublicClient(product_id="ETH-USD")
 ```
 
 ### PublicClient Methods
@@ -45,37 +56,33 @@ public_client.get_products()
 - [getProductOrderBook](https://docs.gdax.com/#get-product-order-book)
 ```python
 # Get the order book at the default level.
-public_client.get_product_order_book()
+public_client.get_product_order_book(product_id='BTC-USD')
 # Get the order book at a specific level.
-public_client.get_product_order_book(level=1)
+public_client.get_product_order_book(product_id='BTC-USD', level=3)
 ```
 
 - [getProductTicker](https://docs.gdax.com/#get-product-ticker)
 ```python
-# Get the product ticker for the default product.
-public_client.get_product_ticker()
 # Get the product ticker for a specific product.
-public_client.get_product_ticker(product="ETH-USD")
+public_client.get_product_ticker(product_id='ETH-USD')
 ```
 
 - [getProductTrades](https://docs.gdax.com/#get-trades)
 ```python
-# Get the product trades for the default product.
-public_client.get_product_trades()
 # Get the product trades for a specific product.
-public_client.get_product_trades(product="ETH-USD")
+public_client.get_product_trades(product_id='ETH-USD')
 ```
 
 - [getProductHistoricRates](https://docs.gdax.com/#get-historic-rates)
 ```python
-public_client.get_product_historic_rates()
+public_client.get_product_historic_rates(product_id='ETH-USD')
 # To include other parameters, see official documentation:
-public_client.get_product_historic_rates(granularity=3000)
+public_client.get_product_historic_rates('ETH-USD', granularity=3000)
 ```
 
 - [getProduct24HrStates](https://docs.gdax.com/#get-24hr-stats)
 ```python
-public_client.get_product_24hr_stats()
+public_client.get_product_24hr_stats('ETH-USD')
 ```
 
 - [getCurrencies](https://docs.gdax.com/#get-currencies)
@@ -88,8 +95,9 @@ public_client.get_currencies()
 public_client.get_time()
 ```
 
-#### *In Development* JSON Parsing
-Only available for the `PublicClient`, you may pass any function above raw JSON data.  This may be useful for some applications of the project and should not hinder performance, but we are looking into this.  *Do you love or hate this?  Please share your thoughts within the issue tab!*
+#### Function Call Methods
+The API presents a consistent interface for parameters, which may be specified 
+in different ways.
 
 - Both of these calls send the same request:
 ```python
@@ -98,12 +106,11 @@ public_client = gdax.PublicClient()
 
 method1 = public_client.get_product_historic_rates(granularity='3000')
 
-params = {
-'granularity': '3000'
-}
-method2 = public_client.get_product_historic_rates(params)
+params = {'granularity': '3000'}
+method2 = public_client.get_product_historic_rates(**params)
 
-# Both methods will send the same request, but not always return the same data if run in series.
+# Both methods will send the same request, but not always return the same data 
+# if run in series because of real-time data changes from GDAX.
 print (method1, method2)
 ```
 
@@ -123,19 +130,29 @@ integrate both into your script.
 import gdax
 auth_client = gdax.AuthenticatedClient(key, b64secret, passphrase)
 # Set a default product
-auth_client = gdax.AuthenticatedClient(key, b64secret, passphrase, product_id="ETH-USD")
+auth_client = gdax.AuthenticatedClient(key, b64secret, 
+                                       passphrase, product_id="ETH-USD")
 # Use the sandbox API (requires a different set of API access credentials)
-auth_client = gdax.AuthenticatedClient(key, b64secret, passphrase, api_url="https://api-public.sandbox.gdax.com")
+auth_client = gdax.AuthenticatedClient(key, b64secret, 
+                                       passphrase, api_url="https://api-public.sandbox.gdax.com")
 ```
 
 ### Pagination
-Some calls are [paginated](https://docs.gdax.com/#pagination), meaning multiple calls must be made to receive the full set of data.  Each page/request is a list of dict objects that are then appended to a master list, making it easy to navigate pages (e.g. ```request[0]``` would return the first page of data in the example below). *This feature is under consideration for redesign.  Please provide feedback if you have issues or suggestions*
+Some calls are [paginated](https://docs.gdax.com/#pagination), meaning multiple 
+calls must be made to receive the full set of data.  Each page/request is a list 
+of dict objects that are then appended to a master list, making it easy to 
+navigate pages (e.g. ```request[0]``` would return the first page of data in the 
+example below). *This feature is under consideration for redesign.  Please 
+provide feedback if you have issues or suggestions*
 ```python
 request = auth_client.get_fills(limit=100)
 request[0] # Page 1 always present
 request[1] # Page 2+ present only if the data exists
 ```
-It should be noted that limit does not behave exactly as the official documentation specifies.  If you request a limit and that limit is met, additional pages will not be returned.  This is to ensure speedy response times when less data is prefered.
+It should be noted that limit does not behave exactly as the official 
+documentation specifies.  If you request a limit and that limit is met, 
+additional pages will not be returned.  This is to ensure speedy response times 
+when less data is preferred.
 
 ### AuthenticatedClient Methods
 - [getAccounts](https://docs.gdax.com/#list-accounts)
@@ -240,11 +257,16 @@ wsClient.close()
 ```
 
 ### WebsocketClient Methods
-The ```WebsocketClient``` subscribes in a separate thread upon initialization.  There are three methods which you could overwrite (before initialization) so it can react to the data streaming in.  The current client is a template used for illustration purposes only.
+The ```WebsocketClient``` subscribes in a separate thread upon initialization. 
+There are three methods which you could overwrite (before initialization) so it 
+can react to the data streaming in.  The current client is a template used for 
+illustration purposes only.
 
-- onOpen - called once, *immediately before* the socket connection is made, this is where you want to add inital parameters.
-- onMessage - called once for every message that arrives and accepts one argument that contains the message of dict type.
-- onClose - called once after the websocket has been closed.
+- on_open - called once, *immediately before* the socket connection is made, this 
+is where you want to add inital parameters.
+- on_message - called once for every message that arrives and accepts one 
+argument that contains the message of dict type.
+- on_close - called once after the websocket has been closed.
 - close - call this method to close the websocket connection (do not overwrite).
 ```python
 import gdax, time
@@ -255,7 +277,7 @@ class myWebsocketClient(gdax.WebsocketClient):
         self.message_count = 0
         print("Lets count the messages!")
     def on_message(self, msg):
-        self.MessageCount += 1
+        self.Message_count += 1
         if 'price' in msg and 'type' in msg:
             print ("Message type:", msg["type"], "\t@ {}.3f".format(float(msg["price"])))
     def on_close(self):
@@ -271,7 +293,9 @@ wsClient.close()
 ```
 
 ### Real-time OrderBook
-The ```OrderBook``` subscribes to a websocket and keeps a real-time record of the orderbook for the product_id input.  Please provide your feedback for future improvements.
+The ```OrderBook``` subscribes to a websocket and keeps a real-time record of 
+the orderbook for the product_id input.  Please provide your feedback for 
+future improvements.
 
 ```python
 import gdax, time
@@ -279,6 +303,16 @@ order_book = gdax.OrderBook(product_id='BTC-USD')
 order_book.start()
 time.sleep(10)
 order_book.close()
+```
+
+### Testing
+Unit tests are under development using the pytest framework. Contributions are 
+welcome!
+
+To run the full test suite, in the project 
+directory run:
+```bash
+python -m pytest
 ```
 
 ## Change Log
@@ -293,7 +327,8 @@ order_book.close()
 - Added additional API functionality such as cancelAll() and ETH withdrawal.
 
 *0.2.1*
-- Allowed ```WebsocketClient``` to operate intuitively and restructured example workflow.
+- Allowed ```WebsocketClient``` to operate intuitively and restructured 
+example workflow.
 
 *0.2.0*
 - Renamed project to GDAX-Python

--- a/gdax/authenticated_client.py
+++ b/gdax/authenticated_client.py
@@ -254,6 +254,46 @@ class AuthenticatedClient(PublicClient):
         params.update(kwargs)
         return self._send_message('post', '/orders', data=json.dumps(params))
 
+    def buy(self, product_id, order_type, **kwargs):
+        """Place a buy order.
+
+        This is included to maintain backwards compatibility with older versions
+        of GDAX-Python. For maximum support from docstrings and function
+        signatures see the order type-specific functions place_limit_order,
+        place_market_order, and place_stop_order.
+
+        Args:
+            product_id (str): Product to order (eg. 'BTC-USD')
+            order_type (str): Order type ('limit', 'market', or 'stop')
+            **kwargs: Additional arguments can be specified for different order
+                types.
+
+        Returns:
+            dict: Order details. See `place_order` for example.
+
+        """
+        return self.place_order(product_id, 'buy', order_type, **kwargs)
+
+    def sell(self, product_id, order_type, **kwargs):
+        """Place a sell order.
+
+        This is included to maintain backwards compatibility with older versions
+        of GDAX-Python. For maximum support from docstrings and function
+        signatures see the order type-specific functions place_limit_order,
+        place_market_order, and place_stop_order.
+
+        Args:
+            product_id (str): Product to order (eg. 'BTC-USD')
+            order_type (str): Order type ('limit', 'market', or 'stop')
+            **kwargs: Additional arguments can be specified for different order
+                types.
+
+        Returns:
+            dict: Order details. See `place_order` for example.
+
+        """
+        return self.place_order(product_id, 'sell', order_type, **kwargs)
+
     def place_limit_order(self, product_id, side, price, size,
                           client_oid=None,
                           stp=None,
@@ -931,7 +971,7 @@ class AuthenticatedClient(PublicClient):
     def get_trailing_volume(self):
         """  Get your 30-day trailing volume for all products.
 
-        This is a cached value that’s calculated every day at midnight UTC.
+        This is a cached value that's calculated every day at midnight UTC.
 
         Returns:
             list: 30-day trailing volumes. Example::
@@ -1006,7 +1046,7 @@ class AuthenticatedClient(PublicClient):
                 break
             else:
                 params['after'] = r.headers['cb-after']
-                
+
 
 class GdaxAuth(AuthBase):
     # Provided by gdax: https://docs.gdax.com/#signing-a-message

--- a/gdax/authenticated_client.py
+++ b/gdax/authenticated_client.py
@@ -974,6 +974,15 @@ class AuthenticatedClient(PublicClient):
         The paginated responses are abstracted away by making API requests on
         demand as the response is iterated over.
 
+        Paginated API messages support 3 additional parameters: `before`,
+        `after`, and `limit`. `before` and `after` are mutually exclusive. To
+        use them, supply an index value for that endpoint (the field used for
+        indexing varies by endpoint - get_fills() uses 'trade_id', for example).
+            `before`: Only get data that occurs more recently than index
+            `after`: Only get data that occurs further in the past than index
+            `limit`: Set amount of data per HTTP response. Default (and
+                maximum) of 100.
+
         Args:
             endpoint (str): Endpoint (to be added to base URL)
             params (Optional[dict]): HTTP request parameters

--- a/gdax/authenticated_client.py
+++ b/gdax/authenticated_client.py
@@ -397,7 +397,7 @@ class AuthenticatedClient(PublicClient):
             params['product_id'] = product_id
         if status is not None:
             params['status'] = status
-        return self._send_paginated_message('/orders', params=kwargs)
+        return self._send_paginated_message('/orders', params=params)
 
     def get_fills(self, product_id=None, order_id=None, **kwargs):
         """ Get a list of recent fills.

--- a/gdax/authenticated_client.py
+++ b/gdax/authenticated_client.py
@@ -990,63 +990,6 @@ class AuthenticatedClient(PublicClient):
         """
         return self._send_message('get', '/users/self/trailing-volume')
 
-    def _send_message(self, method, endpoint, params=None, data=None):
-        """Send API request.
-
-        Args:
-            method (str): HTTP method (get, post, delete, etc.)
-            endpoint (str): Endpoint (to be added to base URL)
-            params (Optional[dict]): HTTP request parameters
-            data (Optional[str]): JSON-encoded string payload for POST
-
-        Returns:
-            dict/list: JSON response
-
-        """
-        url = self.url + endpoint
-        r = self.session.request(method, url, params=params, data=data,
-                                 auth=self.auth, timeout=30)
-        return r.json()
-
-    def _send_paginated_message(self, endpoint, params=None):
-        """ Send API message that results in a paginated response.
-
-        The paginated responses are abstracted away by making API requests on
-        demand as the response is iterated over.
-
-        Paginated API messages support 3 additional parameters: `before`,
-        `after`, and `limit`. `before` and `after` are mutually exclusive. To
-        use them, supply an index value for that endpoint (the field used for
-        indexing varies by endpoint - get_fills() uses 'trade_id', for example).
-            `before`: Only get data that occurs more recently than index
-            `after`: Only get data that occurs further in the past than index
-            `limit`: Set amount of data per HTTP response. Default (and
-                maximum) of 100.
-
-        Args:
-            endpoint (str): Endpoint (to be added to base URL)
-            params (Optional[dict]): HTTP request parameters
-
-        Yields:
-            dict: API response objects
-
-        """
-        url = self.url + endpoint
-        while True:
-            r = self.session.get(url, params=params, auth=self.auth, timeout=30)
-            results = r.json()
-            for result in results:
-                yield result
-            # If there are no more pages, we're done. Otherwise update `after`
-            # param to get next page.
-            # If this request included `before` don't get any more pages - the
-            # GDAX API doesn't support multiple pages in that case.
-            if not r.headers.get('cb-after') or \
-                    params.get('before') is not None:
-                break
-            else:
-                params['after'] = r.headers['cb-after']
-
 
 class GdaxAuth(AuthBase):
     # Provided by gdax: https://docs.gdax.com/#signing-a-message

--- a/gdax/public_client.py
+++ b/gdax/public_client.py
@@ -8,69 +8,244 @@ import requests
 
 
 class PublicClient(object):
-    def __init__(self, api_url="https://api.gdax.com", product_id="BTC-USD"):
-        self.url = api_url.rstrip("/")
-        self.product_id = product_id
+    """GDAX public client API.
+
+    All requests default to the `product_id` specified at object
+    creation if not otherwise specified.
+
+    Attributes:
+        url (Optional[str]): API URL. Defaults to GDAX API.
+
+    """
+
+    def __init__(self, api_url='https://api.gdax.com'):
+        """Create GDAX API public client.
+
+        Args:
+            api_url (Optional[str]): API URL. Defaults to GDAX API.
+
+        """
+        self.url = api_url.rstrip('/')
 
     def get_products(self):
+        """Get a list of available currency pairs for trading.
+
+        Returns:
+            list: Info about all currency pairs. Example::
+                [
+                    {
+                        "id": "BTC-USD",
+                        "display_name": "BTC/USD",
+                        "base_currency": "BTC",
+                        "quote_currency": "USD",
+                        "base_min_size": "0.01",
+                        "base_max_size": "10000.00",
+                        "quote_increment": "0.01"
+                    }
+                ]
+
+        """
         r = requests.get(self.url + '/products')
         # r.raise_for_status()
         return r.json()
 
-    def get_product_order_book(self, json=None, level=2, product=''):
-        if type(json) is dict:
-            if "product" in json:
-                product = json["product"]
-            if "level" in json:
-                level = json['level']
-        r = requests.get(self.url + '/products/{}/book?level={}'.format(product or self.product_id, str(level)))
+    def get_product_order_book(self, product_id, level=1):
+        """Get a list of open orders for a product.
+
+        The amount of detail shown can be customized with the `level`
+        parameter:
+        * 1: Only the best bid and ask
+        * 2: Top 50 bids and asks (aggregated)
+        * 3: Full order book (non aggregated)
+
+        Level 1 and Level 2 are recommended for polling. For the most
+        up-to-date data, consider using the websocket stream.
+
+        **Caution**: Level 3 is only recommended for users wishing to
+        maintain a full real-time order book using the websocket
+        stream. Abuse of Level 3 via polling will cause your access to
+        be limited or blocked.
+
+        Args:
+            product_id (str): Product
+            level (Optional[int]): Order book level (1, 2, or 3).
+                Default is 1.
+
+        Returns:
+            dict: Order book. Example for level 1::
+                {
+                    "sequence": "3",
+                    "bids": [
+                        [ price, size, num-orders ],
+                    ],
+                    "asks": [
+                        [ price, size, num-orders ],
+                    ]
+                }
+
+        """
+        params = {'level': level}
+        r = requests.get(self.url + '/products/{}/book'
+                         .format(product_id), params=params)
         # r.raise_for_status()
         return r.json()
 
-    def get_product_ticker(self, json=None, product=''):
-        if type(json) is dict:
-            if "product" in json:
-                product = json["product"]
-        r = requests.get(self.url + '/products/{}/ticker'.format(product or self.product_id))
+    def get_product_ticker(self, product_id):
+        """Snapshot about the last trade (tick), best bid/ask and 24h volume.
+
+        **Caution**: Polling is discouraged in favor of connecting via
+        the websocket stream and listening for match messages.
+
+        Args:
+            product_id (str): Product
+
+        Returns:
+            dict: Ticker info. Example::
+                {
+                  "trade_id": 4729088,
+                  "price": "333.99",
+                  "size": "0.193",
+                  "bid": "333.98",
+                  "ask": "333.99",
+                  "volume": "5957.11914015",
+                  "time": "2015-11-14T20:46:03.511254Z"
+                }
+
+        """
+        r = requests.get(self.url + '/products/{}/ticker'
+                         .format(product_id))
         # r.raise_for_status()
         return r.json()
 
-    def get_product_trades(self, json=None, product=''):
-        if type(json) is dict:
-            if "product" in json:
-                product = json["product"]
-        r = requests.get(self.url + '/products/{}/trades'.format(product or self.product_id))
+    def get_product_trades(self, product_id):
+        """List the latest trades for a product.
+
+        Args:
+            product_id (str): Product
+
+        Returns:
+            list: Latest trades. Example::
+                [{
+                    "time": "2014-11-07T22:19:28.578544Z",
+                    "trade_id": 74,
+                    "price": "10.00000000",
+                    "size": "0.01000000",
+                    "side": "buy"
+                }, {
+                    "time": "2014-11-07T01:08:43.642366Z",
+                    "trade_id": 73,
+                    "price": "100.00000000",
+                    "size": "0.01000000",
+                    "side": "sell"
+                }]
+
+        """
+        r = requests.get(self.url + '/products/{}/trades'.format(product_id))
         # r.raise_for_status()
         return r.json()
 
-    def get_product_historic_rates(self, json=None, product='', start='', end='', granularity=''):
-        payload = {}
-        if type(json) is dict:
-            if "product" in json:
-                product = json["product"]
-            payload = json
-        else:
-            payload["start"] = start
-            payload["end"] = end
-            payload["granularity"] = granularity
-        r = requests.get(self.url + '/products/{}/candles'.format(product or self.product_id), params=payload)
+    def get_product_historic_rates(self, product_id, start=None, end=None,
+                                   granularity=None):
+        """Historic rates for a product.
+
+        Rates are returned in grouped buckets based on requested
+        `granularity`. If start, end, and granularity aren't provided,
+        the exchange will assume some (currently unknown) default values.
+
+        Historical rate data may be incomplete. No data is published for
+        intervals where there are no ticks.
+
+        **Caution**: Historical rates should not be polled frequently.
+        If you need real-time information, use the trade and book
+        endpoints along with the websocket feed.
+
+        The maximum number of data points for a single request is 200
+        candles. If your selection of start/end time and granularity
+        will result in more than 200 data points, your request will be
+        rejected. If you wish to retrieve fine granularity data over a
+        larger time range, you will need to make multiple requests with
+        new start/end ranges.
+
+        Args:
+            product_id (str): Product
+            start (Optional[str]): Start time in ISO 8601
+            end (Optional[str]): End time in ISO 8601
+            granularity (Optional[str]): Desired time slice in seconds
+
+        Returns:
+            list: Historic candle data. Example::
+                [
+                    [ time, low, high, open, close, volume ],
+                    [ 1415398768, 0.32, 4.2, 0.35, 4.2, 12.3 ],
+                    ...
+                ]
+
+        """
+        params = {}
+        if start is not None:
+            params['start'] = start
+        if end is not None:
+            params['end'] = end
+        if granularity is not None:
+            params['granularity'] = granularity
+        r = requests.get(self.url + '/products/{}/candles'
+                         .format(product_id), params=params)
         # r.raise_for_status()
         return r.json()
 
-    def get_product_24hr_stats(self, json=None, product=''):
-        if type(json) is dict:
-            if "product" in json:
-                product = json["product"]
-        r = requests.get(self.url + '/products/{}/stats'.format(product or self.product_id))
+    def get_product_24hr_stats(self, product_id):
+        """Get 24 hr stats for the product.
+
+        Args:
+            product_id (str): Product
+
+        Returns:
+            dict: 24 hour stats. Volume is in base currency units.
+                Open, high, low are in quote currency units. Example::
+                    {
+                        "open": "34.19000000",
+                        "high": "95.70000000",
+                        "low": "7.06000000",
+                        "volume": "2.41000000"
+                    }
+
+        """
+        r = requests.get(self.url + '/products/{}/stats'.format(product_id))
         # r.raise_for_status()
         return r.json()
 
     def get_currencies(self):
+        """List known currencies.
+
+        Returns:
+            list: List of currencies. Example::
+                [{
+                    "id": "BTC",
+                    "name": "Bitcoin",
+                    "min_size": "0.00000001"
+                }, {
+                    "id": "USD",
+                    "name": "United States Dollar",
+                    "min_size": "0.01000000"
+                }]
+
+        """
         r = requests.get(self.url + '/currencies')
         # r.raise_for_status()
         return r.json()
 
     def get_time(self):
+        """Get the API server time.
+
+        Returns:
+            dict: Server time in ISO and epoch format (decimal seconds
+                since Unix epoch). Example::
+                    {
+                        "iso": "2015-01-07T23:47:25.201Z",
+                        "epoch": 1420674445.201
+                    }
+
+        """
         r = requests.get(self.url + '/time')
         # r.raise_for_status()
         return r.json()

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ install_requires = [
     'websocket-client==0.40.0',
 ]
 
+tests_require = [
+    'pytest',
+    ]
+
 setup(
     name='gdax',
     version='0.3.1',
@@ -18,6 +22,7 @@ setup(
     url='https://github.com/danpaquin/GDAX-Python',
     packages=find_packages(),
     install_requires=install_requires,
+    tests_require=tests_require,
     description='The unofficial Python client for the GDAX API',
     download_url='https://github.com/danpaquin/GDAX-Python/archive/master.zip',
     keywords=['gdax', 'gdax-api', 'orderbook', 'trade', 'bitcoin', 'ethereum', 'BTC', 'ETH', 'client', 'api', 'wrapper', 'exchange', 'crypto', 'currency', 'trading', 'trading-api', 'coinbase'],

--- a/tests/api_config.json.example
+++ b/tests/api_config.json.example
@@ -1,0 +1,3 @@
+{"passphrase": "passhere",
+ "b64secret": "secrethere",
+ "key": "key here"}

--- a/tests/test_authenticated_client.py
+++ b/tests/test_authenticated_client.py
@@ -1,4 +1,7 @@
 import pytest
+import json
+import time
+from itertools import islice
 import gdax
 
 
@@ -9,7 +12,7 @@ def dc():
 
 
 @pytest.mark.usefixtures('dc')
-class TestAuthenticatedClient(object):
+class TestAuthenticatedClientSyntax(object):
     def test_place_order_input_1(self, dc):
         with pytest.raises(ValueError):
             r = dc.place_order('BTC-USD', 'buy', 'market',
@@ -34,3 +37,151 @@ class TestAuthenticatedClient(object):
         with pytest.raises(ValueError):
             r = dc.place_order('BTC-USD', 'buy', 'market',
                                size=1, funds=1)
+
+
+@pytest.fixture(scope='module')
+def client():
+    """Client that connects to sandbox API. Relies on authentication information
+    provided in api_config.json"""
+    with open('api_config.json') as file:
+        api_config = json.load(file)
+    c = gdax.AuthenticatedClient(
+        api_url='https://api-public.sandbox.gdax.com', **api_config)
+
+    # Set up account with deposits and orders. Do this by depositing from
+    # the Coinbase USD wallet, which has a fixed value of > $10,000.
+    #
+    # Only deposit if the balance is below some nominal amount. The
+    # exchange seems to freak out if you run up your account balance.
+    coinbase_accounts = c.get_coinbase_accounts()
+    account_info = [x for x in coinbase_accounts
+                    if x['name'] == 'USD Wallet'][0]
+    account_usd = account_info['id']
+    if float(account_info['balance']) < 70000:
+        c.coinbase_deposit(10000, 'USD', account_usd)
+    # Place some orders to generate history
+    c.place_limit_order('BTC-USD', 'buy', 1, 0.01)
+    c.place_limit_order('BTC-USD', 'buy', 2, 0.01)
+    c.place_limit_order('BTC-USD', 'buy', 3, 0.01)
+
+    return c
+
+
+@pytest.mark.usefixtures('dc')
+class TestAuthenticatedClient(object):
+    """Test the authenticated client by validating basic behavior from the
+    sandbox exchange."""
+    def test_get_accounts(self, client):
+        r = client.get_accounts()
+        assert type(r) is list
+        assert 'currency' in r[0]
+        # Now get a single account
+        r = client.get_account(account_id=r[0]['id'])
+        assert type(r) is dict
+        assert 'currency' in r
+
+    def test_account_history(self, client):
+        accounts = client.get_accounts()
+        account_usd = [x for x in accounts if x['currency'] == 'USD'][0]['id']
+        r = list(islice(client.get_account_history(account_usd), 5))
+        assert type(r) is list
+        assert 'amount' in r[0]
+        assert 'details' in r[0]
+
+        # Now exercise the pagination abstraction. Setting limit to 1 means
+        # each record comes in a separate HTTP response.
+        history_gen = client.get_account_history(account_usd, limit=1)
+        r = list(islice(history_gen, 2))
+        r2 = list(islice(history_gen, 2))
+        assert r != r2
+        # Now exercise the `before` parameter.
+        r3 = list(client.get_account_history(account_usd, before=r2[0]['id']))
+        assert r3 == r
+
+    def test_get_account_holds(self, client):
+        accounts = client.get_accounts()
+        account_usd = [x for x in accounts if x['currency'] == 'USD'][0]['id']
+        r = list(client.get_account_holds(account_usd))
+        assert type(r) is list
+        assert 'type' in r[0]
+        assert 'ref' in r[0]
+
+    def test_place_order(self, client):
+        r = client.place_order('BTC-USD', 'buy', 'limit',
+                               price=0.62, size=0.0144)
+        assert type(r) is dict
+        assert r['stp'] == 'dc'
+
+    def test_place_limit_order(self, client):
+        r = client.place_limit_order('BTC-USD', 'buy', 4.43, 0.01232)
+        assert type(r) is dict
+        assert 'executed_value' in r
+        assert not r['post_only']
+        client.cancel_order(r['id'])
+
+    def test_place_market_order(self, client):
+        r = client.place_market_order('BTC-USD', 'buy', size=0.01)
+        assert 'status' in r
+        assert r['type'] == 'market'
+        client.cancel_order(r['id'])
+
+        # This one probably won't go through
+        r = client.place_market_order('BTC-USD', 'buy', funds=100000)
+        assert type(r) is dict
+
+    def test_place_stop_order(self, client):
+        client.cancel_all()
+        r = client.place_stop_order('BTC-USD', 'buy', 1, 0.01)
+        assert type(r) is dict
+        assert r['type'] == 'stop'
+        client.cancel_order(r['id'])
+
+    def test_cancel_order(self, client):
+        r = client.place_limit_order('BTC-USD', 'buy', 4.43, 0.01232)
+        time.sleep(0.2)
+        r2 = client.cancel_order(r['id'])
+        assert r2[0] == r['id']
+
+    def test_cancel_all(self, client):
+        r = client.cancel_all()
+        assert type(r) is list
+
+    def test_get_order(self, client):
+        r = client.place_limit_order('BTC-USD', 'buy', 4.43, 0.01232)
+        time.sleep(0.2)
+        r2 = client.get_order(r['id'])
+        assert r2['id'] == r['id']
+
+    def test_get_orders(self, client):
+        r = list(islice(client.get_orders(), 10))
+        assert type(r) is list
+        assert 'created_at' in r[0]
+
+    def test_get_fills(self, client):
+        r = list(islice(client.get_orders(), 10))
+        assert type(r) is list
+        assert 'fill_fees' in r[0]
+
+    def test_get_fundings(self, client):
+        r = list(islice(client.get_fundings(), 10))
+        assert type(r) is list
+
+    def test_repay_funding(self, client):
+        # This request gets denied
+        r = client.repay_funding(2.1, 'USD')
+
+    def test_get_position(self, client):
+        r = client.get_position()
+        assert 'accounts' in r
+
+    def test_get_payment_methods(self, client):
+        r = client.get_payment_methods()
+        assert type(r) is list
+
+    def test_get_coinbase_accounts(self, client):
+        r = client.get_coinbase_accounts()
+        assert type(r) is list
+
+    def test_get_trailing_volume(self, client):
+        r = client.get_trailing_volume()
+        assert type(r) is list

--- a/tests/test_authenticated_client.py
+++ b/tests/test_authenticated_client.py
@@ -1,0 +1,36 @@
+import pytest
+import gdax
+
+
+@pytest.fixture(scope='module')
+def dc():
+    """Dummy client for testing."""
+    return gdax.AuthenticatedClient('test', 'test', 'test')
+
+
+@pytest.mark.usefixtures('dc')
+class TestAuthenticatedClient(object):
+    def test_place_order_input_1(self, dc):
+        with pytest.raises(ValueError):
+            r = dc.place_order('BTC-USD', 'buy', 'market',
+                               overdraft_enabled='true', funding_amount=10)
+
+    def test_place_order_input_2(self, dc):
+        with pytest.raises(ValueError):
+            r = dc.place_order('BTC-USD', 'buy', 'limit',
+                               cancel_after='123', tif='ABC')
+
+    def test_place_order_input_3(self, dc):
+        with pytest.raises(ValueError):
+            r = dc.place_order('BTC-USD', 'buy', 'limit',
+                               post_only='true', tif='FOK')
+
+    def test_place_order_input_4(self, dc):
+        with pytest.raises(ValueError):
+            r = dc.place_order('BTC-USD', 'buy', 'market',
+                               size=None, funds=None)
+
+    def test_place_order_input_5(self, dc):
+        with pytest.raises(ValueError):
+            r = dc.place_order('BTC-USD', 'buy', 'market',
+                               size=1, funds=1)

--- a/tests/test_public_client.py
+++ b/tests/test_public_client.py
@@ -1,0 +1,52 @@
+import pytest
+import gdax
+
+
+@pytest.fixture(scope='module')
+def client():
+    return gdax.PublicClient()
+
+
+@pytest.mark.usefixtures('client')
+class TestPublicClient(object):
+    def test_get_products(self, client):
+        r = client.get_products()
+        assert type(r) is list
+
+    def test_get_product_order_book(self, client):
+        r = client.get_product_order_book()
+        assert type(r) is dict
+        r = client.get_product_order_book(level=2)
+        assert type(r) is dict
+        assert 'asks' in r
+        assert 'bids' in r
+
+    def test_get_product_ticker(self, client):
+        r = client.get_product_ticker()
+        assert type(r) is dict
+        assert 'ask' in r
+        assert 'trade_id' in r
+
+    def test_get_product_trades(self, client):
+        r = client.get_product_trades()
+        assert type(r) is list
+        assert 'trade_id' in r[0]
+
+    def test_get_historic_rates(self, client):
+        r = client.get_product_historic_rates()
+        assert type(r) is list
+
+    def test_get_product_24hr_stats(self, client):
+        r = client.get_product_24hr_stats()
+        assert type(r) is dict
+        assert 'volume_30day' in r
+
+    def test_get_currencies(self, client):
+        r = client.get_currencies()
+        assert type(r) is list
+        assert 'name' in r[0]
+
+    def test_get_time(self, client):
+        r = client.get_time()
+        assert type(r) is dict
+        assert 'iso' in r

--- a/tests/test_public_client.py
+++ b/tests/test_public_client.py
@@ -1,4 +1,5 @@
 import pytest
+from itertools import islice
 import gdax
 
 
@@ -28,7 +29,7 @@ class TestPublicClient(object):
         assert 'trade_id' in r
 
     def test_get_product_trades(self, client):
-        r = client.get_product_trades('BTC-USD')
+        r = list(islice(client.get_product_trades('BTC-USD'), 200))
         assert type(r) is list
         assert 'trade_id' in r[0]
 


### PR DESCRIPTION
This is an overhaul of the AuthenticatedClient. A summary:
* Consistent interface for all endpoints (#60)
* Paginated requests have been abstracted away in the form of generators (#64)
* Docstrings for all methods (#56)
* Tests for as many authenticated endpoints as possible. Sandbox API credentials need to be supplied to run the tests (instructions in readme). The sandbox API is a little flaky, so some tests randomly fail. Not the best testing methodology, but it exercises most of the functions at least.

An AuthenticatedClient object now makes all HTTP calls through a single requests.Session. This may give a performance boost when making many calls to the GDAX API and should remain thead-safe. All HTTP requests are made through helper functions for cleaner code, and should also make implementing error handling simple to do in the future. These changes are implemented in PublicClient as well.

This PR has breaking changes in the interface, so we can discuss how to integrate without losing sync between Github and pypi again. Maybe push this to a version branch, and then merge to master when ready to update pypi?

Thanks to @Jigsaw-Jams for writing most of the docstrings!