### PR TITLE
Fixed crash when changing a market order

### DIFF
--- a/gdax/order_book.py
+++ b/gdax/order_book.py
@@ -156,7 +156,11 @@ class OrderBook(WebsocketClient):
                 self.set_asks(price, asks)
 
     def change(self, order):
-        new_size = Decimal(order['new_size'])
+        try:
+            new_size = Decimal(order['new_size'])
+        except KeyError:
+            return
+            
         price = Decimal(order['price'])
 
         if order['side'] == 'buy':


### PR DESCRIPTION
Change messages for market orders don't have "new_size" and if the change message is for a market order, no action is needed.