### PR TITLE
python3 compatible print

### DIFF
--- a/gdax/authenticated_client.py
+++ b/gdax/authenticated_client.py
@@ -294,7 +294,7 @@ class GdaxAuth(AuthBase):
     def __call__(self, request):
         timestamp = str(time.time())
         message = timestamp + request.method + request.path_url + (request.body or '')
-        print message
+        print(message)
         message = message.encode('ascii')
         hmac_key = base64.b64decode(self.secret_key)
         signature = hmac.new(hmac_key, message, hashlib.sha256)


### PR DESCRIPTION
Maybe the print was ment only for debug.
Like this, the package is not importable in python3.