### PR TITLE
Add the product_id property to AuthenticatedClient.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ integrate both into your script.
 ```python
 import gdax
 auth_client = gdax.AuthenticatedClient(key, b64secret, passphrase)
-# Set a default product
+# Set a default product for subsequent calls. If not specified, "BTC-USD" is used.
 auth_client = gdax.AuthenticatedClient(key, b64secret, passphrase, 
                                        product_id="ETH-USD")
 # Use the sandbox API (requires a different set of API access credentials)

--- a/gdax/authenticated_client.py
+++ b/gdax/authenticated_client.py
@@ -15,9 +15,10 @@ from gdax.public_client import PublicClient
 
 
 class AuthenticatedClient(PublicClient):
-    def __init__(self, key, b64secret, passphrase, api_url="https://api.gdax.com"):
+    def __init__(self, key, b64secret, passphrase, api_url="https://api.gdax.com", product_id="BTC-USD"):
         super(AuthenticatedClient, self).__init__(api_url)
         self.auth = GdaxAuth(key, b64secret, passphrase)
+        self.product_id = product_id
 
     def get_account(self, account_id):
         r = requests.get(self.url + '/accounts/' + account_id, auth=self.auth)


### PR DESCRIPTION
This was erroneously removed in e1b47d. References to self.product_id cause AttributeError exceptions.

Also update the relevant documentation.

I know the AuthenticatedClient is being overhauled in #81, but just want to add it here until that PR is merged, should any users run into this problem.