### PR TITLE
wait the thread ends before close the ws, otherwise, it causes seg fault

### DIFF
--- a/gdax/websocket_client.py
+++ b/gdax/websocket_client.py
@@ -83,6 +83,7 @@ class WebsocketClient(object):
                 self.ws.send(json.dumps({"type": "heartbeat", "on": False}))
             self.on_close()
             self.stop = True
+            self.thread.join()
             try:
                 if self.ws:
                     self.ws.close()


### PR DESCRIPTION
I'm getting seg fault without having "self.thread.join()" in the close() function.