### PR TITLE
Reset WebsocketClient.stop to False when calling .start()

### DIFF
--- a/gdax/websocket_client.py
+++ b/gdax/websocket_client.py
@@ -32,6 +32,7 @@ class WebsocketClient(object):
             self._connect()
             self._listen()
 
+        self.stop = False
         self.on_open()
         self.thread = Thread(target=_go)
         self.thread.start()


### PR DESCRIPTION
WebsocketClient.stop is set to True when .close() is called, but it is never
set back to False when start() is called, so _listen() never runs.