### PR TITLE
Re-initialize OrderBook on open

### DIFF
--- a/gdax/order_book.py
+++ b/gdax/order_book.py
@@ -29,6 +29,13 @@ class OrderBook(WebsocketClient):
         ''' Currently OrderBook only supports a single product even though it is stored as a list of products. '''
         return self.products[0]
 
+    def on_open(self):
+        self._sequence = -1
+        print("-- Subscribed to OrderBook! --\n")
+
+    def on_close(self):
+        print("\n-- OrderBook Socket Closed! --")
+
     def on_message(self, message):
         if self._log_to:
             pickle.dump(message, self._log_to)


### PR DESCRIPTION
If OrderBook is closed, then reopened, the accuracy of the data can no longer
be trusted. Setting _sequence = -1 on open resets the _asks and _bids members
as well so we can start with a fresh and accurate OrderBook.