### PR TITLE
Fixes crash on changing market sell

### DIFF
--- a/gdax/order_book.py
+++ b/gdax/order_book.py
@@ -160,8 +160,11 @@ class OrderBook(WebsocketClient):
             new_size = Decimal(order['new_size'])
         except KeyError:
             return
-            
-        price = Decimal(order['price'])
+
+        try:
+            price = Decimal(order['price'])
+        except KeyError:
+            return
 
         if order['side'] == 'buy':
             bids = self.get_bids(price)


### PR DESCRIPTION
I think this should fix all the errors with changing market orders.  When a market buy is changed it only has "new_funds" but not "new_size".  When a market sell is changed it has a "new_size" but no "price".