### PR TITLE
Websocket PyMongo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # gdax-python
-The Python client for the [GDAX API](https://docs.gdax.com/) (formerly known as 
+The Python client for the [GDAX API](https://docs.gdax.com/) (formerly known as
 the Coinbase Exchange API)
 
 ##### Provided under MIT License by Daniel Paquin.
-*Note: this library may be subtly broken or buggy. The code is released under 
+*Note: this library may be subtly broken or buggy. The code is released under
 the MIT License – please take the following message to heart:*
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ## Benefits
 - A simple to use python wrapper for both public and authenticated endpoints.
-- In about 10 minutes, you could be programmatically trading on one of the 
+- In about 10 minutes, you could be programmatically trading on one of the
 largest Bitcoin exchanges in the *world*!
-- Do not worry about handling the nuances of the API with easy-to-use methods 
+- Do not worry about handling the nuances of the API with easy-to-use methods
 for every API endpoint.
-- Gain an advantage in the market by getting under the hood of GDAX to learn 
+- Gain an advantage in the market by getting under the hood of GDAX to learn
 what and who is *really* behind every tick.
 
 ## Under Development
@@ -27,10 +27,10 @@ what and who is *really* behind every tick.
 - FIX API Client **Looking for assistance**
 
 ## Getting Started
-This README is documentation on the syntax of the python client presented in 
+This README is documentation on the syntax of the python client presented in
 this repository. See function docstrings for full syntax details.  
-**This API attempts to present a clean interface to GDAX, but in order to use it 
-to its full potential, you must familiarize yourself with the official GDAX 
+**This API attempts to present a clean interface to GDAX, but in order to use it
+to its full potential, you must familiarize yourself with the official GDAX
 documentation.**
 
 - https://docs.gdax.com/
@@ -41,7 +41,7 @@ pip install gdax
 ```
 
 ### Public Client
-Only some endpoints in the API are available to everyone.  The public endpoints 
+Only some endpoints in the API are available to everyone.  The public endpoints
 can be reached using ```PublicClient```
 
 ```python
@@ -111,28 +111,28 @@ integrate both into your script.
 import gdax
 auth_client = gdax.AuthenticatedClient(key, b64secret, passphrase)
 # Set a default product
-auth_client = gdax.AuthenticatedClient(key, b64secret, passphrase, 
+auth_client = gdax.AuthenticatedClient(key, b64secret, passphrase,
                                        product_id="ETH-USD")
 # Use the sandbox API (requires a different set of API access credentials)
-auth_client = gdax.AuthenticatedClient(key, b64secret, passphrase, 
+auth_client = gdax.AuthenticatedClient(key, b64secret, passphrase,
                                   api_url="https://api-public.sandbox.gdax.com")
 ```
 
 ### Pagination
-Some calls are [paginated](https://docs.gdax.com/#pagination), meaning multiple 
-calls must be made to receive the full set of data.  Each page/request is a list 
-of dict objects that are then appended to a master list, making it easy to 
-navigate pages (e.g. ```request[0]``` would return the first page of data in the 
-example below). *This feature is under consideration for redesign.  Please 
+Some calls are [paginated](https://docs.gdax.com/#pagination), meaning multiple
+calls must be made to receive the full set of data.  Each page/request is a list
+of dict objects that are then appended to a master list, making it easy to
+navigate pages (e.g. ```request[0]``` would return the first page of data in the
+example below). *This feature is under consideration for redesign.  Please
 provide feedback if you have issues or suggestions*
 ```python
 request = auth_client.get_fills(limit=100)
 request[0] # Page 1 always present
 request[1] # Page 2+ present only if the data exists
 ```
-It should be noted that limit does not behave exactly as the official 
-documentation specifies.  If you request a limit and that limit is met, 
-additional pages will not be returned.  This is to ensure speedy response times 
+It should be noted that limit does not behave exactly as the official
+documentation specifies.  If you request a limit and that limit is met,
+additional pages will not be returned.  This is to ensure speedy response times
 when less data is preferred.
 
 ### AuthenticatedClient Methods
@@ -217,7 +217,7 @@ auth_client.withdraw(withdrawParams)
 ```
 
 ### WebsocketClient
-If you would like to receive real-time market updates, you must subscribe to the 
+If you would like to receive real-time market updates, you must subscribe to the
 [websocket feed](https://docs.gdax.com/#websocket-feed).
 
 #### Subscribe to a single product
@@ -233,21 +233,38 @@ wsClient.close()
 ```python
 import gdax
 # Paramaters are optional
-wsClient = gdax.WebsocketClient(url="wss://ws-feed.gdax.com", 
+wsClient = gdax.WebsocketClient(url="wss://ws-feed.gdax.com",
                                 products=["BTC-USD", "ETH-USD"])
 # Do other stuff...
 wsClient.close()
 ```
 
+### WebsocketClient + Mongodb
+The ```WebsocketClient``` now supports data gathering via MongoDB. Given a
+MongoDB collection, the ```WebsocketClient``` will stream results directly into
+the database collection. 
+```python
+# import PyMongo and connect to a local, running Mongo instance
+from pymongo import MongoClient
+mongo_client = MongoClient('mongodb://localhost:27017/')
+# specify the database and collection
+db = mongo_client.cryptocurrency_database
+BTC_collection = db.BTC_collection
+# instantiate a WebsocketClient instance, with a Mongo collection as a parameter
+wsClient = WebsocketClient(url="wss://ws-feed.gdax.com", products="BTC-USD",
+    mongo_collection=BTC_collection, should_print=False)
+wsClient.start()
+```
+
 ### WebsocketClient Methods
-The ```WebsocketClient``` subscribes in a separate thread upon initialization. 
-There are three methods which you could overwrite (before initialization) so it 
-can react to the data streaming in.  The current client is a template used for 
+The ```WebsocketClient``` subscribes in a separate thread upon initialization.
+There are three methods which you could overwrite (before initialization) so it
+can react to the data streaming in.  The current client is a template used for
 illustration purposes only.
 
-- onOpen - called once, *immediately before* the socket connection is made, this 
+- onOpen - called once, *immediately before* the socket connection is made, this
 is where you want to add inital parameters.
-- onMessage - called once for every message that arrives and accepts one 
+- onMessage - called once for every message that arrives and accepts one
 argument that contains the message of dict type.
 - onClose - called once after the websocket has been closed.
 - close - call this method to close the websocket connection (do not overwrite).
@@ -262,7 +279,7 @@ class myWebsocketClient(gdax.WebsocketClient):
     def on_message(self, msg):
         self.message_count += 1
         if 'price' in msg and 'type' in msg:
-            print ("Message type:", msg["type"], 
+            print ("Message type:", msg["type"],
                    "\t@ {:.3f}".format(float(msg["price"])))
     def on_close(self):
         print("-- Goodbye! --")
@@ -275,16 +292,17 @@ while (wsClient.message_count < 500):
     time.sleep(1)
 wsClient.close()
 ```
+
 ## Testing
-A test suite is under development. To run the tests, start in the project 
+A test suite is under development. To run the tests, start in the project
 directory and run
 ```
 python -m pytest
 ```
 
 ### Real-time OrderBook
-The ```OrderBook``` subscribes to a websocket and keeps a real-time record of 
-the orderbook for the product_id input.  Please provide your feedback for future 
+The ```OrderBook``` subscribes to a websocket and keeps a real-time record of
+the orderbook for the product_id input.  Please provide your feedback for future
 improvements.
 
 ```python
@@ -297,7 +315,7 @@ order_book.close()
 
 ## Change Log
 *1.0* **Current PyPI release**
-- The first release that is not backwards compatible 
+- The first release that is not backwards compatible
 - Refactored to follow PEP 8 Standards
 - Improved Documentation
 
@@ -312,7 +330,7 @@ order_book.close()
 - Added additional API functionality such as cancelAll() and ETH withdrawal.
 
 *0.2.1*
-- Allowed ```WebsocketClient``` to operate intuitively and restructured example 
+- Allowed ```WebsocketClient``` to operate intuitively and restructured example
 workflow.
 
 *0.2.0*

--- a/gdax/websocket_client.py
+++ b/gdax/websocket_client.py
@@ -1,6 +1,7 @@
-#
 # gdax/WebsocketClient.py
-# Daniel Paquin
+# original author: Daniel Paquin
+# mongo "support" added by Drew Rice
+#
 #
 # Template object to receive messages from the gdax Websocket Feed
 

--- a/gdax/websocket_client.py
+++ b/gdax/websocket_client.py
@@ -28,6 +28,7 @@ class WebsocketClient(object):
         self.api_key = api_key
         self.api_secret = api_secret
         self.api_passphrase = api_passphrase
+        self.should_print = should_print
         self.mongo_collection = mongo_collection
 
     def start(self):
@@ -96,13 +97,15 @@ class WebsocketClient(object):
                 pass
 
     def on_open(self):
-        print("-- Subscribed! --\n")
+        if self.should_print:
+            print("-- Subscribed! --\n")
 
     def on_close(self):
-        print("\n-- Socket Closed --")
+        if self.should_print:
+            print("\n-- Socket Closed --")
 
     def on_message(self, msg):
-        if should_print:
+        if self.should_print:
             print(msg)
         if self.mongo_collection: # dump JSON to given mongo collection
             self.mongo_collection.insert_one(msg)

--- a/gdax/websocket_client.py
+++ b/gdax/websocket_client.py
@@ -12,10 +12,11 @@ import hashlib
 import time
 from threading import Thread
 from websocket import create_connection, WebSocketConnectionClosedException
-
+from pymongo import MongoClient
 
 class WebsocketClient(object):
-    def __init__(self, url="wss://ws-feed.gdax.com", products=None, message_type="subscribe", auth=False, api_key="", api_secret="", api_passphrase=""):
+    def __init__(self, url="wss://ws-feed.gdax.com", products=None, message_type="subscribe",
+            mongo_collection=None, should_print=True, auth=False, api_key="", api_secret="", api_passphrase=""):
         self.url = url
         self.products = products
         self.type = message_type
@@ -26,6 +27,7 @@ class WebsocketClient(object):
         self.api_key = api_key
         self.api_secret = api_secret
         self.api_passphrase = api_passphrase
+        self.mongo_collection = mongo_collection
 
     def start(self):
         def _go():
@@ -99,7 +101,10 @@ class WebsocketClient(object):
         print("\n-- Socket Closed --")
 
     def on_message(self, msg):
-        print(msg)
+        if should_print:
+            print(msg)
+        if self.mongo_collection: # dump JSON to given mongo collection
+            self.mongo_collection.insert_one(msg)
 
     def on_error(self, e):
         print(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ bintrees==2.0.7
 requests==2.13.0
 six==1.10.0
 websocket-client==0.40.0
+pymongo


### PR DESCRIPTION
The purpose of this PR is to allow users of the WebsocketClient streaming API to dump the contents to a Mongodb collection. With the inclusion of a new parameter `should_print`, which defaults to True, existing functionality should be unchanged. In the case of data collection, a user can pass a Mongo collection object to the WebsocketClient at instantiation and stream the results to the database in realtime. 