### PR TITLE
add local file to store API creds and load into env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 venv/
 *log.txt
 gdax/__pycache__/
+credentials.json

--- a/README.md
+++ b/README.md
@@ -102,7 +102,17 @@ public_client.get_time()
 Not all API endpoints are available to everyone.
 Those requiring user authentication can be reached using `AuthenticatedClient`.
 You must setup API access within your
-[account settings](https://www.gdax.com/settings/api).
+[account settings](https://www.gdax.com/settings/api). You can add your API
+credentials to `credentials.json`, which will load your credentials as
+environment variables at runtime.
+
+```python
+key = os.environ.get('sandbox_key')
+b64secret = os.environ.get('sandbox_secret')
+passphrase = os.environ.get('sandbox_password')
+```
+
+
 The `AuthenticatedClient` inherits all methods from the `PublicClient`
 class, so you will only need to initialize one if you are planning to
 integrate both into your script.
@@ -115,6 +125,8 @@ auth_client = gdax.AuthenticatedClient(key, b64secret, passphrase)
 auth_client = gdax.AuthenticatedClient(key, b64secret, passphrase,
                                   api_url="https://api-public.sandbox.gdax.com")
 ```
+
+You can
 
 ### Pagination
 Some calls are [paginated](https://docs.gdax.com/#pagination), meaning multiple
@@ -240,7 +252,7 @@ wsClient.close()
 ### WebsocketClient + Mongodb
 The ```WebsocketClient``` now supports data gathering via MongoDB. Given a
 MongoDB collection, the ```WebsocketClient``` will stream results directly into
-the database collection. 
+the database collection.
 ```python
 # import PyMongo and connect to a local, running Mongo instance
 from pymongo import MongoClient
@@ -261,9 +273,9 @@ can react to the data streaming in.  The current client is a template used for
 illustration purposes only.
 
 
-- onOpen - called once, *immediately before* the socket connection is made, this 
+- onOpen - called once, *immediately before* the socket connection is made, this
 is where you want to add initial parameters.
-- onMessage - called once for every message that arrives and accepts one 
+- onMessage - called once for every message that arrives and accepts one
 argument that contains the message of dict type.
 - onClose - called once after the websocket has been closed.
 - close - call this method to close the websocket connection (do not overwrite).

--- a/credentials.json
+++ b/credentials.json
@@ -1,0 +1,8 @@
+{
+  "sandbox_key": "SANDBOX_API_KEY",
+  "sandbox_secret": "SANDBOX_API_SECRET",
+  "sandbox_password": "SANDBOX_API_PASSPHRASE",
+  "live_key": "LIVE_API_KEY",
+  "live_secret": "LIVE_API_SECRET",
+  "live_password": "LIVE_API_PASSPHRASE"
+}

--- a/gdax/__init__.py
+++ b/gdax/__init__.py
@@ -2,3 +2,11 @@ from gdax.authenticated_client import AuthenticatedClient
 from gdax.public_client import PublicClient
 from gdax.websocket_client import WebsocketClient
 from gdax.order_book import OrderBook
+
+import json
+import os
+
+# Import API Keys
+with open('credentials.json') as creds:
+    credentials = json.load(creds)
+    os.environ.update(credentials)

--- a/gdax/public_client.py
+++ b/gdax/public_client.py
@@ -5,8 +5,7 @@
 # For public requests to the GDAX exchange
 
 import requests
-from pandas import to_datetime, to_timedelta
-from time import sleep
+
 
 class PublicClient(object):
     """GDAX public client API.
@@ -141,7 +140,8 @@ class PublicClient(object):
                 }]
 
         """
-        r = requests.get(self.url + '/products/{}/trades'.format(product_id), timeout=30)
+        r = requests.get(self.url + '/products/{}/trades'.format(product_id),
+                         timeout=30)
         # r.raise_for_status()
         return r.json()
 
@@ -194,33 +194,6 @@ class PublicClient(object):
         # r.raise_for_status()
         return r.json()
 
-    def get_extended_product_historic_rates(self, product_id, start, end,
-                                            granularity):
-        """ Helper function for requesting longer term product histories.
-        """
-        max_data_points = 200
-        public_rate_limit_seconds = 3
-
-        start = to_datetime(start)
-        end = to_datetime(end)
-        history = []
-
-        request_start = start
-        request_end = request_start + to_timedelta(granularity*max_data_points, 's')
-
-        while request_end < end:
-            prices = self.get_product_historic_rates(product_id, start=request_start.isoformat(),
-                                                              end=request_end.isoformat(), granularity=granularity)
-            history.extend(prices[::-1])
-            request_start = request_end
-            request_end = request_start + to_timedelta(granularity*max_data_points, 's')
-            sleep((1/public_rate_limit_seconds)+0.01)
-
-        if end - request_end > to_timedelta(0, 's'):
-            history.extend(self.get_product_historic_rates(product_id, start=request_start.isoformat(),
-                                                              end=request_end.isoformat(), granularity=granularity))
-        return history
-
     def get_product_24hr_stats(self, product_id):
         """Get 24 hr stats for the product.
 
@@ -238,7 +211,8 @@ class PublicClient(object):
                     }
 
         """
-        r = requests.get(self.url + '/products/{}/stats'.format(product_id), timeout=30)
+        r = requests.get(self.url + '/products/{}/stats'.format(product_id),
+                         timeout=30)
         # r.raise_for_status()
         return r.json()
 


### PR DESCRIPTION
- Created a `credentials.json` file where users can add their API keys.
- Loads credentials into environment variables at runtime. 
- Added `credentials.json` to `.gitignore` so that users don't accidentally push their keys to a public repo. 

Please excuse the messy commit history, I'm still learning git and I hadn't created a new branch for this PR.

This PR also includes a commit to fix a few lines >79 chars. I see you've refactored to follow PEP8 standards, one of them specifies a [maximum line length](https://www.python.org/dev/peps/pep-0008/#maximum-line-length). 