### PR TITLE
Improvements to gdax public client

### DIFF
--- a/gdax/public_client.py
+++ b/gdax/public_client.py
@@ -27,6 +27,13 @@ class PublicClient(object):
         """
         self.url = api_url.rstrip('/')
 
+    def _get(self, path, params=None):
+        """Perform get request"""
+
+        r = requests.get(self.url + path, params=params, timeout=30)
+        # r.raise_for_status()
+        return r.json()
+
     def get_products(self):
         """Get a list of available currency pairs for trading.
 
@@ -45,9 +52,7 @@ class PublicClient(object):
                 ]
 
         """
-        r = requests.get(self.url + '/products', timeout=30)
-        # r.raise_for_status()
-        return r.json()
+        return self._get('/products')
 
     def get_product_order_book(self, product_id, level=1):
         """Get a list of open orders for a product.
@@ -84,11 +89,10 @@ class PublicClient(object):
                 }
 
         """
-        params = {'level': level}
-        r = requests.get(self.url + '/products/{}/book'
-                         .format(product_id), params=params, timeout=30)
-        # r.raise_for_status()
-        return r.json()
+
+        # Supported levels are 1, 2 or 3
+        level = level if level in range(1, 4) else 1
+        return self._get('/products/{}/book'.format(str(product_id)), params={'level': level})
 
     def get_product_ticker(self, product_id):
         """Snapshot about the last trade (tick), best bid/ask and 24h volume.
@@ -112,10 +116,7 @@ class PublicClient(object):
                 }
 
         """
-        r = requests.get(self.url + '/products/{}/ticker'
-                         .format(product_id), timeout=30)
-        # r.raise_for_status()
-        return r.json()
+        return self._get('/products/{}/ticker'.format(str(product_id)))
 
     def get_product_trades(self, product_id):
         """List the latest trades for a product.
@@ -140,9 +141,7 @@ class PublicClient(object):
                 }]
 
         """
-        r = requests.get(self.url + '/products/{}/trades'.format(product_id), timeout=30)
-        # r.raise_for_status()
-        return r.json()
+        return self._get('/products/{}/trades'.format(str(product_id)))
 
     def get_product_historic_rates(self, product_id, start=None, end=None,
                                    granularity=None):
@@ -188,10 +187,8 @@ class PublicClient(object):
             params['end'] = end
         if granularity is not None:
             params['granularity'] = granularity
-        r = requests.get(self.url + '/products/{}/candles'
-                         .format(product_id), params=params, timeout=30)
-        # r.raise_for_status()
-        return r.json()
+
+        return self._get('/products/{}/candles'.format(str(product_id)), params=params)
 
     def get_product_24hr_stats(self, product_id):
         """Get 24 hr stats for the product.
@@ -210,9 +207,7 @@ class PublicClient(object):
                     }
 
         """
-        r = requests.get(self.url + '/products/{}/stats'.format(product_id), timeout=30)
-        # r.raise_for_status()
-        return r.json()
+        return self._get('/products/{}/stats'.format(str(product_id)))
 
     def get_currencies(self):
         """List known currencies.
@@ -230,9 +225,7 @@ class PublicClient(object):
                 }]
 
         """
-        r = requests.get(self.url + '/currencies', timeout=30)
-        # r.raise_for_status()
-        return r.json()
+        return self._get('/currencies')
 
     def get_time(self):
         """Get the API server time.
@@ -246,6 +239,4 @@ class PublicClient(object):
                     }
 
         """
-        r = requests.get(self.url + '/time', timeout=30)
-        # r.raise_for_status()
-        return r.json()
+        return self._get('/time')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --cov gdax/ --cov-report=term-missing
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ requests==2.13.0
 six==1.10.0
 websocket-client==0.40.0
 pymongo==3.5.1
+pytest>=3.3.0
+pytest-cov>=2.5.0

--- a/tests/test_public_client.py
+++ b/tests/test_public_client.py
@@ -1,5 +1,6 @@
 import pytest
 import gdax
+import time
 
 
 @pytest.fixture(scope='module')
@@ -9,17 +10,30 @@ def client():
 
 @pytest.mark.usefixtures('client')
 class TestPublicClient(object):
+
+    @staticmethod
+    def teardown_method():
+        time.sleep(.25)  # Avoid rate limit
+
     def test_get_products(self, client):
         r = client.get_products()
         assert type(r) is list
 
-    def test_get_product_order_book(self, client):
-        r = client.get_product_order_book('BTC-USD')
-        assert type(r) is dict
-        r = client.get_product_order_book('BTC-USD', level=2)
+    @pytest.mark.parametrize('level', [1, 2, 3, None])
+    def test_get_product_order_book(self, client, level):
+        r = client.get_product_order_book('BTC-USD', level=level)
         assert type(r) is dict
         assert 'asks' in r
         assert 'bids' in r
+
+        if level in (1, None) and (len(r['asks']) > 1 or len(r['bids']) > 1):
+            pytest.fail('Fail: Level 1 should only return the best ask and bid')
+
+        if level is 2 and (len(r['asks']) > 50 or len(r['bids']) > 50):
+            pytest.fail('Fail: Level 2 should only return the top 50 asks and bids')
+
+        if level is 2 and (len(r['asks']) < 50 or len(r['bids']) < 50):
+            pytest.fail('Fail: Level 3 should return the full order book')
 
     def test_get_product_ticker(self, client):
         r = client.get_product_ticker('BTC-USD')
@@ -32,8 +46,11 @@ class TestPublicClient(object):
         assert type(r) is list
         assert 'trade_id' in r[0]
 
-    def test_get_historic_rates(self, client):
-        r = client.get_product_historic_rates('BTC-USD')
+    @pytest.mark.parametrize('start', ('2017-11-01', None))
+    @pytest.mark.parametrize('end', ('2017-11-30', None))
+    @pytest.mark.parametrize('granularity', (3600, None))
+    def test_get_historic_rates(self, client, start, end, granularity):
+        r = client.get_product_historic_rates('BTC-USD', start=start, end=end, granularity=granularity)
         assert type(r) is list
 
     def test_get_product_24hr_stats(self, client):


### PR DESCRIPTION
Consolidate all requests.get into single call

Removing duplicate code on all the Public client gets. 
Get product order book should check for invalid levels

Default to level 1
Add pytest-cov

pytest-cov provides coverage reports
Parametrize order book test

Test get product order book with multiple levels
Add wait between tests to avoid rate limits


Parameterize historic rates test

Add parameters for start, end and granularity