### PR TITLE
Allow setting a timeout value when initializing the clients to override the default of 30 seconds

### DIFF
--- a/gdax/authenticated_client.py
+++ b/gdax/authenticated_client.py
@@ -16,12 +16,13 @@ from gdax.gdax_auth import GdaxAuth
 
 
 class AuthenticatedClient(PublicClient):
-    def __init__(self, key, b64secret, passphrase, api_url="https://api.gdax.com"):
+    def __init__(self, key, b64secret, passphrase, api_url="https://api.gdax.com", timeout=30):
         super(AuthenticatedClient, self).__init__(api_url)
         self.auth = GdaxAuth(key, b64secret, passphrase)
+        self.timeout = timeout
 
     def get_account(self, account_id):
-        r = requests.get(self.url + '/accounts/' + account_id, auth=self.auth, timeout=30)
+        r = requests.get(self.url + '/accounts/' + account_id, auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
@@ -30,7 +31,7 @@ class AuthenticatedClient(PublicClient):
 
     def get_account_history(self, account_id):
         result = []
-        r = requests.get(self.url + '/accounts/{}/ledger'.format(account_id), auth=self.auth, timeout=30)
+        r = requests.get(self.url + '/accounts/{}/ledger'.format(account_id), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         result.append(r.json())
         if "cb-after" in r.headers:
@@ -38,7 +39,7 @@ class AuthenticatedClient(PublicClient):
         return result
 
     def history_pagination(self, account_id, result, after):
-        r = requests.get(self.url + '/accounts/{}/ledger?after={}'.format(account_id, str(after)), auth=self.auth, timeout=30)
+        r = requests.get(self.url + '/accounts/{}/ledger?after={}'.format(account_id, str(after)), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         if r.json():
             result.append(r.json())
@@ -48,7 +49,7 @@ class AuthenticatedClient(PublicClient):
 
     def get_account_holds(self, account_id):
         result = []
-        r = requests.get(self.url + '/accounts/{}/holds'.format(account_id), auth=self.auth, timeout=30)
+        r = requests.get(self.url + '/accounts/{}/holds'.format(account_id), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         result.append(r.json())
         if "cb-after" in r.headers:
@@ -56,7 +57,7 @@ class AuthenticatedClient(PublicClient):
         return result
 
     def holds_pagination(self, account_id, result, after):
-        r = requests.get(self.url + '/accounts/{}/holds?after={}'.format(account_id, str(after)), auth=self.auth, timeout=30)
+        r = requests.get(self.url + '/accounts/{}/holds?after={}'.format(account_id, str(after)), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         if r.json():
             result.append(r.json())
@@ -71,7 +72,7 @@ class AuthenticatedClient(PublicClient):
         r = requests.post(self.url + '/orders',
                           data=json.dumps(kwargs),
                           auth=self.auth,
-                          timeout=30)
+                          timeout=self.timeout)
         return r.json()
 
     def sell(self, **kwargs):
@@ -79,11 +80,11 @@ class AuthenticatedClient(PublicClient):
         r = requests.post(self.url + '/orders',
                           data=json.dumps(kwargs),
                           auth=self.auth,
-                          timeout=30)
+                          timeout=self.timeout)
         return r.json()
 
     def cancel_order(self, order_id):
-        r = requests.delete(self.url + '/orders/' + order_id, auth=self.auth, timeout=30)
+        r = requests.delete(self.url + '/orders/' + order_id, auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
@@ -91,12 +92,12 @@ class AuthenticatedClient(PublicClient):
         url = self.url + '/orders/'
         if product_id:
             url += "?product_id={}&".format(str(product_id))
-        r = requests.delete(url, auth=self.auth, timeout=30)
+        r = requests.delete(url, auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
     def get_order(self, order_id):
-        r = requests.get(self.url + '/orders/' + order_id, auth=self.auth, timeout=30)
+        r = requests.get(self.url + '/orders/' + order_id, auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
@@ -108,7 +109,7 @@ class AuthenticatedClient(PublicClient):
             params["product_id"] = product_id
         if status:
             params["status"] = status
-        r = requests.get(url, auth=self.auth, params=params, timeout=30)
+        r = requests.get(url, auth=self.auth, params=params, timeout=self.timeout)
         # r.raise_for_status()
         result.append(r.json())
         if 'cb-after' in r.headers:
@@ -125,7 +126,7 @@ class AuthenticatedClient(PublicClient):
             params["product_id"] = product_id
         if status:
             params["status"] = status
-        r = requests.get(url, auth=self.auth, params=params, timeout=30)
+        r = requests.get(url, auth=self.auth, params=params, timeout=self.timeout)
         # r.raise_for_status()
         if r.json():
             result.append(r.json())
@@ -146,7 +147,7 @@ class AuthenticatedClient(PublicClient):
             url += "after={}&".format(str(after))
         if limit:
             url += "limit={}&".format(str(limit))
-        r = requests.get(url, auth=self.auth, timeout=30)
+        r = requests.get(url, auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         result.append(r.json())
         if 'cb-after' in r.headers and limit is not len(r.json()):
@@ -159,7 +160,7 @@ class AuthenticatedClient(PublicClient):
             url += "order_id={}&".format(str(order_id))
         if product_id:
             url += "product_id={}&".format(product_id)
-        r = requests.get(url, auth=self.auth, timeout=30)
+        r = requests.get(url, auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         if r.json():
             result.append(r.json())
@@ -175,7 +176,7 @@ class AuthenticatedClient(PublicClient):
             url += "status={}&".format(str(status))
         if after:
             url += 'after={}&'.format(str(after))
-        r = requests.get(url, auth=self.auth, timeout=30)
+        r = requests.get(url, auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         result.append(r.json())
         if 'cb-after' in r.headers:
@@ -187,7 +188,7 @@ class AuthenticatedClient(PublicClient):
             "amount": amount,
             "currency": currency  # example: USD
         }
-        r = requests.post(self.url + "/funding/repay", data=json.dumps(payload), auth=self.auth, timeout=30)
+        r = requests.post(self.url + "/funding/repay", data=json.dumps(payload), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
@@ -198,12 +199,12 @@ class AuthenticatedClient(PublicClient):
             "currency": currency,  # example: USD
             "amount": amount
         }
-        r = requests.post(self.url + "/profiles/margin-transfer", data=json.dumps(payload), auth=self.auth, timeout=30)
+        r = requests.post(self.url + "/profiles/margin-transfer", data=json.dumps(payload), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
     def get_position(self):
-        r = requests.get(self.url + "/position", auth=self.auth, timeout=30)
+        r = requests.get(self.url + "/position", auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
@@ -211,7 +212,7 @@ class AuthenticatedClient(PublicClient):
         payload = {
             "repay_only": repay_only or False
         }
-        r = requests.post(self.url + "/position/close", data=json.dumps(payload), auth=self.auth, timeout=30)
+        r = requests.post(self.url + "/position/close", data=json.dumps(payload), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
@@ -221,7 +222,7 @@ class AuthenticatedClient(PublicClient):
             "currency": currency,
             "payment_method_id": payment_method_id
         }
-        r = requests.post(self.url + "/deposits/payment-method", data=json.dumps(payload), auth=self.auth, timeout=30)
+        r = requests.post(self.url + "/deposits/payment-method", data=json.dumps(payload), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
@@ -231,7 +232,7 @@ class AuthenticatedClient(PublicClient):
             "currency": currency,
             "coinbase_account_id": coinbase_account_id
         }
-        r = requests.post(self.url + "/deposits/coinbase-account", data=json.dumps(payload), auth=self.auth, timeout=30)
+        r = requests.post(self.url + "/deposits/coinbase-account", data=json.dumps(payload), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
@@ -241,7 +242,7 @@ class AuthenticatedClient(PublicClient):
             "currency": currency,
             "payment_method_id": payment_method_id
         }
-        r = requests.post(self.url + "/withdrawals/payment-method", data=json.dumps(payload), auth=self.auth, timeout=30)
+        r = requests.post(self.url + "/withdrawals/payment-method", data=json.dumps(payload), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
@@ -251,7 +252,7 @@ class AuthenticatedClient(PublicClient):
             "currency": currency,
             "coinbase_account_id": coinbase_account_id
         }
-        r = requests.post(self.url + "/withdrawals/coinbase", data=json.dumps(payload), auth=self.auth, timeout=30)
+        r = requests.post(self.url + "/withdrawals/coinbase", data=json.dumps(payload), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
@@ -261,17 +262,17 @@ class AuthenticatedClient(PublicClient):
             "currency": currency,
             "crypto_address": crypto_address
         }
-        r = requests.post(self.url + "/withdrawals/crypto", data=json.dumps(payload), auth=self.auth, timeout=30)
+        r = requests.post(self.url + "/withdrawals/crypto", data=json.dumps(payload), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
     def get_payment_methods(self):
-        r = requests.get(self.url + "/payment-methods", auth=self.auth, timeout=30)
+        r = requests.get(self.url + "/payment-methods", auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
     def get_coinbase_accounts(self):
-        r = requests.get(self.url + "/coinbase-accounts", auth=self.auth, timeout=30)
+        r = requests.get(self.url + "/coinbase-accounts", auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
@@ -286,16 +287,16 @@ class AuthenticatedClient(PublicClient):
             "format": report_format,
             "email": email
         }
-        r = requests.post(self.url + "/reports", data=json.dumps(payload), auth=self.auth, timeout=30)
+        r = requests.post(self.url + "/reports", data=json.dumps(payload), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
     def get_report(self, report_id=""):
-        r = requests.get(self.url + "/reports/" + report_id, auth=self.auth, timeout=30)
+        r = requests.get(self.url + "/reports/" + report_id, auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 
     def get_trailing_volume(self):
-        r = requests.get(self.url + "/users/self/trailing-volume", auth=self.auth, timeout=30)
+        r = requests.get(self.url + "/users/self/trailing-volume", auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()

--- a/gdax/public_client.py
+++ b/gdax/public_client.py
@@ -18,7 +18,7 @@ class PublicClient(object):
 
     """
 
-    def __init__(self, api_url='https://api.gdax.com'):
+    def __init__(self, api_url='https://api.gdax.com', timeout=30):
         """Create GDAX API public client.
 
         Args:
@@ -26,11 +26,12 @@ class PublicClient(object):
 
         """
         self.url = api_url.rstrip('/')
+        self.timeout = timeout
 
     def _get(self, path, params=None):
         """Perform get request"""
 
-        r = requests.get(self.url + path, params=params, timeout=30)
+        r = requests.get(self.url + path, params=params, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 


### PR DESCRIPTION
This is useful when you are trading quickly and do not want to proceed once a certain number of seconds have passed. When GDAX is being slow it is often preferable to fail early, recalculate your order price and try again otherwise you are more likely to be charged a fee when you hit the market rate.