### PR TITLE
Fix withdraw to coinbase account bug/ unit test fixes

### DIFF
--- a/gdax/authenticated_client.py
+++ b/gdax/authenticated_client.py
@@ -252,7 +252,7 @@ class AuthenticatedClient(PublicClient):
             "currency": currency,
             "coinbase_account_id": coinbase_account_id
         }
-        r = requests.post(self.url + "/withdrawals/coinbase", data=json.dumps(payload), auth=self.auth, timeout=self.timeout)
+        r = requests.post(self.url + "/withdrawals/coinbase-account", data=json.dumps(payload), auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
 

--- a/gdax/gdax_auth.py
+++ b/gdax/gdax_auth.py
@@ -14,8 +14,11 @@ class GdaxAuth(AuthBase):
 
     def __call__(self, request):
         timestamp = str(time.time())
-        message = timestamp + request.method + request.path_url + (request.body or '')
-        request.headers.update(get_auth_headers(timestamp, message, self.api_key, self.secret_key,
+        message = ''.join([timestamp, request.method,
+                           request.path_url, (request.body or '')])
+        request.headers.update(get_auth_headers(timestamp, message,
+                                                self.api_key,
+                                                self.secret_key,
                                                 self.passphrase))
         return request
 

--- a/tests/test_public_client.py
+++ b/tests/test_public_client.py
@@ -1,6 +1,8 @@
 import pytest
 import gdax
 import time
+import datetime
+from dateutil.relativedelta import relativedelta
 
 
 @pytest.fixture(scope='module')
@@ -46,9 +48,11 @@ class TestPublicClient(object):
         assert type(r) is list
         assert 'trade_id' in r[0]
 
-    @pytest.mark.parametrize('start', ('2017-11-01', None))
-    @pytest.mark.parametrize('end', ('2017-11-30', None))
-    @pytest.mark.parametrize('granularity', (3600, None))
+    current_time = datetime.datetime.now()
+
+    @pytest.mark.parametrize('start,end,granularity',
+                             [(current_time - relativedelta(months=1),
+                               current_time, 10000)])
     def test_get_historic_rates(self, client, start, end, granularity):
         r = client.get_product_historic_rates('BTC-USD', start=start, end=end, granularity=granularity)
         assert type(r) is list


### PR DESCRIPTION
#204 Rest Endpoint we should be using here is /withdrawals/coinbase-account as per documentation.
https://docs.gdax.com/?python#payment-method53
Thoughts on these changes?
Thanks,