### PR TITLE
Connection is already closed: send ping based on time elapsed

### DIFF
--- a/gdax/websocket_client.py
+++ b/gdax/websocket_client.py
@@ -84,9 +84,11 @@ class WebsocketClient(object):
     def _listen(self):
         while not self.stop:
             try:
-                if int(time.time() % 30) == 0:
+                start_t = 0
+                if time.time() - start_t >= 30:
                     # Set a 30 second ping to keep connection alive
                     self.ws.ping("keepalive")
+                    start_t = time.time()
                 data = self.ws.recv()
                 msg = json.loads(data)
             except ValueError as e:


### PR DESCRIPTION
It seems that the modulus operation at [websocket_client.py#L87](https://github.com/danpaquin/gdax-python/blob/14a88c3/gdax/websocket_client.py#L87) could be fragile, e.g. if `time.time()` does not return an exact 30s increment, the ping will be skipped. This PR switches over to a check based on the time elapsed.

Related to #211 