### PR TITLE
Generate GDAX Deposit Address

### DIFF
--- a/gdax/authenticated_client.py
+++ b/gdax/authenticated_client.py
@@ -300,3 +300,8 @@ class AuthenticatedClient(PublicClient):
         r = requests.get(self.url + "/users/self/trailing-volume", auth=self.auth, timeout=self.timeout)
         # r.raise_for_status()
         return r.json()
+
+    def get_deposit_address(self, account_id):
+        r = requests.post(self.url + '/coinbase-accounts/{}/addresses'.format(account_id), auth=self.auth, timeout=self.timeout)
+        # r.raise_for_status()
+        return r.json()


### PR DESCRIPTION
Adding a method to generate and populate GDAX deposit addresses.  This is an undocumented feature but can be referenced from the Coinbase GitHub exchange found here: https://github.com/coinbase/gdax-node/issues/91