### PR TITLE
Adding test execution artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist/
 venv/
 *log.txt
 gdax/__pycache__/
+.cache/
+.coverage
+tests/__pycache__/


### PR DESCRIPTION
Simply adding some additional folders/files to be untracked. These are generated when running pytest.