### PR TITLE
Fix heartbeat subscribe message not containing sequence

### DIFF
--- a/gdax/order_book.py
+++ b/gdax/order_book.py
@@ -60,7 +60,7 @@ class OrderBook(WebsocketClient):
         if self._log_to:
             pickle.dump(message, self._log_to)
 
-        sequence = message['sequence']
+        sequence = message.get('sequence', -1)
         if self._sequence == -1:
             self.reset_book()
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ bintrees==2.0.7
 requests==2.13.0
 six==1.10.0
 websocket-client==0.40.0
-pymongo==3.5.1
+pymongo==3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ bintrees==2.0.7
 requests==2.13.0
 six==1.10.0
 websocket-client==0.40.0
-pymongo==3.6.0
+pymongo==3.5.1


### PR DESCRIPTION
Something might have changed at GDAX where the first received message does not contain a sequence anymore. Getting the sequence and defaulting to -1 if nothing is found fixes the issue.