### PR TITLE
Fix websocket client heartbeat startup failure

### DIFF
--- a/gdax/websocket_client.py
+++ b/gdax/websocket_client.py
@@ -74,10 +74,6 @@ class WebsocketClient(object):
 
         self.ws = create_connection(self.url)
 
-        if self.type == "heartbeat":
-            sub_params = {"type": "heartbeat", "on": True}
-        else:
-            sub_params = {"type": "heartbeat", "on": False}
         self.ws.send(json.dumps(sub_params))
 
     def _listen(self):
@@ -98,8 +94,6 @@ class WebsocketClient(object):
                 self.on_message(msg)
 
     def _disconnect(self):
-        if self.type == "heartbeat":
-            self.ws.send(json.dumps({"type": "heartbeat", "on": False}))
         try:
             if self.ws:
                 self.ws.close()


### PR DESCRIPTION
The websocket client fails to start up because the clause that checks for a message type of "heartbeat" clobbers any previously established sub_params, no matter what the value of self.type is. "heartbeat" is actually a channel and should be handled accordingly, i.e. via the channels argument list like so:
```python
wsClient = gdax.WebsocketClient(url="wss://ws-feed.gdax.com",
                                products=["BTC-USD"], channels=['heartbeat'])
```