### PR TITLE
Fix websocket client channel subscription

### DIFF
--- a/gdax/websocket_client.py
+++ b/gdax/websocket_client.py
@@ -73,11 +73,6 @@ class WebsocketClient(object):
             sub_params['timestamp'] = timestamp
 
         self.ws = create_connection(self.url)
-
-        if self.type == "heartbeat":
-            sub_params = {"type": "heartbeat", "on": True}
-        else:
-            sub_params = {"type": "heartbeat", "on": False}
         self.ws.send(json.dumps(sub_params))
 
     def _listen(self):


### PR DESCRIPTION
Heartbeat subscription was implemented incorrectly.

The heartbeat channel is subscribed to just like any other channel (https://docs.gdax.com/#channels):

```
// Request
{
    "type": "subscribe",
    "channels": [{ "name": "heartbeat", "product_ids": ["ETH-EUR"] }]
}
```

rather than `{"type": "heartbeat", "on": True}`.

More importantly, the deleted lines were overwriting `sub_params`, making subscription to any channel impossible.