### PR TITLE
 Allow get_product_trades() to be paginated

### DIFF
--- a/gdax/public_client.py
+++ b/gdax/public_client.py
@@ -120,6 +120,30 @@ class PublicClient(object):
         return self._get('/products/{}/ticker'.format(str(product_id)))
 
     def get_product_trades(self, product_id, before='', after='', limit='', result=[]):
+        """List the latest trades for a product.
+        Args:
+             product_id (str): Product
+             before (Optional[str]): start time in ISO 8601
+             after (Optional[str]): end time in ISO 8601
+             limit (Optional[int]): the desired number of trades (can be more than 100,
+                          automatically paginated)
+             results (Optional[list]): list of results that is used for the pagination
+        Returns:
+             list: Latest trades. Example::
+                 [{
+                     "time": "2014-11-07T22:19:28.578544Z",
+                     "trade_id": 74,
+                     "price": "10.00000000",
+                     "size": "0.01000000",
+                     "side": "buy"
+                 }, {
+                     "time": "2014-11-07T01:08:43.642366Z",
+                     "trade_id": 73,
+                     "price": "100.00000000",
+                     "size": "0.01000000",
+                     "side": "sell"
+         }]
+        """"
         url = self.url + '/products/{}/trades'.format(str(product_id))
         params = {}
 

--- a/gdax/public_client.py
+++ b/gdax/public_client.py
@@ -157,7 +157,7 @@ class PublicClient(object):
             params['limit'] = limit
 
         r = requests.get(url, params=params)
-        r.raise_for_status()
+        # r.raise_for_status()
 
         result.extend(r.json())
 
@@ -167,8 +167,8 @@ class PublicClient(object):
             if limit <= 0:
                 return result
 
-            # ensure that we don't get rate-limited/blocked
-            time.sleep(0.4)
+            # TODO: need a way to ensure that we don't get rate-limited/blocked
+            # time.sleep(0.4)
             return self.get_product_trades(product_id=product_id, after=r.headers['cb-after'], limit=limit, result=result)
 
         return result


### PR DESCRIPTION
This implements the pagination of trades, as per the api docs (https://docs.gdax.com/#get-trades).