### PR TITLE
Fix SyntaxError: EOL while scanning string literal

### DIFF
--- a/gdax/public_client.py
+++ b/gdax/public_client.py
@@ -143,7 +143,7 @@ class PublicClient(object):
                      "size": "0.01000000",
                      "side": "sell"
          }]
-        """"
+        """
         url = self.url + '/products/{}/trades'.format(str(product_id))
         params = {}
 


### PR DESCRIPTION
Code is broken due to an extra comment character. Here is the patch.